### PR TITLE
Merge tooltips into master to add hooks and tooltip kwargs

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -11,6 +11,7 @@ This file contains a list of all the authors of widgets in this repository. Plea
   * `Balloon`
   * `ItemsCanvas`
   * `TimeLine`
+  * `hook.py` and `tooltips.py` modules
 - The Python Team
   * `Calendar`, found [here](http://svn.python.org/projects/sandbox/trunk/ttk-gsoc/samples/ttkcalendar.py)
 - Mitja Martini

--- a/docs/source/ttkwidgets/ttkwidgets.rst
+++ b/docs/source/ttkwidgets/ttkwidgets.rst
@@ -22,4 +22,3 @@ ttkwidgets
     Table
     TickScale
     TimeLine
-    

--- a/docs/source/ttkwidgets/ttkwidgets/ttkwidgets.hook.rst
+++ b/docs/source/ttkwidgets/ttkwidgets/ttkwidgets.hook.rst
@@ -1,0 +1,5 @@
+Widget Option Hooks
+===================
+
+.. currentmodule:: ttkwidgets
+.. automodule:: hook

--- a/docs/source/ttkwidgets/ttkwidgets/ttkwidgets.tooltips.rst
+++ b/docs/source/ttkwidgets/ttkwidgets/ttkwidgets.tooltips.rst
@@ -1,0 +1,5 @@
+Tooltips
+========
+
+.. currentmodule:: ttkwidgets
+.. automodule:: tooltips

--- a/examples/example_hook.py
+++ b/examples/example_hook.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) RedFantom 2021
+# For license see LICENSE
+from tkinter import ttk
+import tkinter as tk
+from ttkwidgets.hook import hook_ttk_widgets
+
+if __name__ == '__main__':
+    hook_ttk_widgets(lambda s, o, v: print(s, o, v), {"tooltip": "Default Value"})
+    hook_ttk_widgets(lambda s, o, v: print(s, o, v), {"hello_world": "second_hook"})
+
+    original_init = ttk.Button.__init__
+
+    def __init__(self, *args, **kwargs):
+        print("User custom hook")
+        original_init(self, *args, **kwargs)
+
+    ttk.Button.__init__ = __init__
+
+    window = tk.Tk()
+    button = ttk.Button(window, text="Destroy", command=window.destroy, tooltip="Destroys Window")
+    button.pack()
+    print([name for name in dir(button) if name.startswith("WidgetHook")])
+    window.after(1000, lambda: button.configure(tooltip="Does not destroy window", command=lambda: None))
+    window.mainloop()

--- a/examples/example_tooltips.py
+++ b/examples/example_tooltips.py
@@ -9,5 +9,8 @@ from ttkwidgets import tooltips  # Import once, use everywhere
 
 
 window = tk.Tk()
-ttk.Button(window, text="Destroy", command=window.destroy, tooltip="This button destroys the window.").pack()
+button = ttk.Button(window, text="Destroy", command=window.destroy, tooltip="This button destroys the window.")
+button.pack()
+x = lambda: button.configure(tooltip="This button no longer destroys the window", command=lambda: print("Behaviour changed!"))
+window.after(5000, x)
 window.mainloop()

--- a/examples/example_tooltips.py
+++ b/examples/example_tooltips.py
@@ -1,0 +1,13 @@
+"""
+Author: RedFantom
+License: GNU GPLv3
+Source: The ttkwidgets repository
+"""
+import tkinter as tk
+from tkinter import ttk
+from ttkwidgets import tooltips  # Import once, use everywhere
+
+
+window = tk.Tk()
+ttk.Button(window, text="Destroy", command=window.destroy, tooltip="This button destroys the window.").pack()
+window.mainloop()

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -11,11 +11,6 @@ except ImportError:
     import tkinter as tk
     from tkinter import ttk
 from ttkwidgets.hook import hook_ttk_widgets, generate_hook_name, is_hooked
-
-
-def printf(*args, **kwargs):
-    kwargs["flush"] = True
-    print(*args, **kwargs)
     
 
 class TestHooks(TestCase):
@@ -30,10 +25,7 @@ class TestHooks(TestCase):
 
     def basic_updater(self, widget, option, value):
         if option not in self.expected:
-            print("basic_updater is expecting {} and got {}: {}, so it is ignored".format(
-                self.expected, option, value))
             return
-        printf("basic_updater is expecting {} and got {}: {}".format(self.expected, option, value))
         self.assertEquals(value, self.expected[option], "Invalid value for {}: {}".format(option, value))
         self.updated = True
         self.expected.clear()
@@ -56,21 +48,17 @@ class TestHooks(TestCase):
         return updated
 
     def test_basic_hook(self):
-        printf("Started test_basic_hook")
         self.expected = {"tooltip": "Hello World"}
-        printf("test_basic_hook is expecting:", self.expected)
         options = {"tooltip": "Default Value"}
         hook_ttk_widgets(self.basic_updater, options)
-        ttk.Button(tooltip="Hello World")
+        button = ttk.Button(tooltip="Hello World")
         self.assertTrue(self.has_been_updated())
 
         self.assertTrue(is_hooked(options))
         self.assertTrue(hasattr(ttk.Button, generate_hook_name(options)))
-
-        printf("Finished test_basic_hook")
+        self.assertTrue("tooltip" in button.keys())
 
     def test_user_hook_and_defaults(self):
-        printf("Started test_user_hook", flush=True)
         self.expected = {"not_user": "Hello World"}
         options = self.expected.copy()
         hook_ttk_widgets(self.basic_updater, self.expected.copy())
@@ -83,19 +71,15 @@ class TestHooks(TestCase):
 
         ttk.Button.__init__ = __init__
 
-        printf("test_user_hook is expecting: ", self.expected)
         ttk.Button()
         self.assertTrue(self.user_hook_called)
         self.assertTrue(is_hooked(options))
         self.assertTrue(self.has_been_updated())
-        printf("Finished test_user_hook")
 
     def test_multi_hooks(self):
-        printf("Started test_multi_hooks")
         options1 = {"hook1": "Default One"}
         options2 = {"hook2": "Default Two"}
         self.expected = {"hook1": "Custom One"}
-        printf("test_multi_hooks is expecting: ", self.expected)
         self.second_expected = {"hook2": "Default Two"}
 
         name = hook_ttk_widgets(self.basic_updater, options1)
@@ -105,14 +89,15 @@ class TestHooks(TestCase):
         self.assertTrue(is_hooked(options1))
         self.assertTrue(is_hooked(options2))
 
-        ttk.Button(hook1="Custom One")
+        button = ttk.Button(hook1="Custom One")
 
         self.assertTrue(is_hooked(options1))
         self.assertTrue(is_hooked(options2))
 
         self.assertTrue(self.has_been_updated())
         self.assertTrue(self.has_been_second_updated())
-        printf("Finished test_multi_hooks")
+
+        self.assertTrue("hook1" in button.keys() and "hook2" in button.keys())
 
     def tearDown(self):
         self.window.destroy()

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -48,15 +48,15 @@ class TestHooks(TestCase):
         return updated and len(self.expected) == 0
 
     def test_basic_hook(self):
-        self.expected = {"tooltip": "Hello World"}
-        options = {"tooltip": "Default Value"}
+        self.expected = {"random_kwarg": "Hello World"}
+        options = {"random_kwarg": "Default Value"}
         hook_ttk_widgets(self.basic_updater, options)
-        button = ttk.Button(tooltip="Hello World")
+        button = ttk.Button(random_kwarg="Hello World")
         self.assertTrue(self.has_been_updated())
 
         self.assertTrue(is_hooked(options))
         self.assertTrue(hasattr(ttk.Button, generate_hook_name(options)))
-        self.assertTrue("tooltip" in button.keys())
+        self.assertTrue("random_kwarg" in button.keys())
 
     def test_user_hook_and_defaults(self):
         self.expected = {"not_user": "Hello World"}

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -13,21 +13,37 @@ except ImportError:
 from ttkwidgets.hook import hook_ttk_widgets, generate_hook_name, is_hooked
 
 
+def printf(*args, **kwargs):
+    kwargs["flush"] = True
+    print(*args, **kwargs)
+    
+
 class TestHooks(TestCase):
 
     def setUp(self):
+        self.window = tk.Tk()
         self.expected = {None: None}
         self.updated = False
         self.user_hook_called = False
         self.second_updated = False
+        self.second_expected = {None: None}
 
     def basic_updater(self, widget, option, value):
-        self.assertTrue(option in self.expected)
-        self.assertEquals(value, self.expected[option])
+        if option not in self.expected:
+            print("basic_updater is expecting {} and got {}: {}, so it is ignored".format(
+                self.expected, option, value))
+            return
+        printf("basic_updater is expecting {} and got {}: {}".format(self.expected, option, value))
+        self.assertEquals(value, self.expected[option], "Invalid value for {}: {}".format(option, value))
         self.updated = True
+        self.expected.clear()
 
     def second_updater(self, widget, option, value):
+        if option not in self.second_expected:
+            return  # Not updated with desired option
+        self.assertEquals(value, self.second_expected[option])
         self.second_updated = True
+        self.second_expected.clear()
 
     def has_been_updated(self):
         updated = self.updated
@@ -40,7 +56,9 @@ class TestHooks(TestCase):
         return updated
 
     def test_basic_hook(self):
+        printf("Started test_basic_hook")
         self.expected = {"tooltip": "Hello World"}
+        printf("test_basic_hook is expecting:", self.expected)
         options = {"tooltip": "Default Value"}
         hook_ttk_widgets(self.basic_updater, options)
         ttk.Button(tooltip="Hello World")
@@ -49,8 +67,12 @@ class TestHooks(TestCase):
         self.assertTrue(is_hooked(options))
         self.assertTrue(hasattr(ttk.Button, generate_hook_name(options)))
 
+        printf("Finished test_basic_hook")
+
     def test_user_hook_and_defaults(self):
+        printf("Started test_user_hook", flush=True)
         self.expected = {"not_user": "Hello World"}
+        options = self.expected.copy()
         hook_ttk_widgets(self.basic_updater, self.expected.copy())
 
         button_init = ttk.Button.__init__
@@ -61,15 +83,20 @@ class TestHooks(TestCase):
 
         ttk.Button.__init__ = __init__
 
+        printf("test_user_hook is expecting: ", self.expected)
         ttk.Button()
         self.assertTrue(self.user_hook_called)
-        self.assertTrue(is_hooked(self.expected))
+        self.assertTrue(is_hooked(options))
         self.assertTrue(self.has_been_updated())
+        printf("Finished test_user_hook")
 
     def test_multi_hooks(self):
+        printf("Started test_multi_hooks")
         options1 = {"hook1": "Default One"}
         options2 = {"hook2": "Default Two"}
         self.expected = {"hook1": "Custom One"}
+        printf("test_multi_hooks is expecting: ", self.expected)
+        self.second_expected = {"hook2": "Default Two"}
 
         name = hook_ttk_widgets(self.basic_updater, options1)
         hook_ttk_widgets(self.second_updater, options2)
@@ -85,4 +112,8 @@ class TestHooks(TestCase):
 
         self.assertTrue(self.has_been_updated())
         self.assertTrue(self.has_been_second_updated())
+        printf("Finished test_multi_hooks")
+
+    def tearDown(self):
+        self.window.destroy()
 

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,0 +1,88 @@
+"""
+Author: RedFantom
+License: GNU GPLv3
+Source: The ttkwidgets repository
+"""
+from unittest import TestCase
+try:
+    import Tkinter as tk
+    import ttk
+except ImportError:
+    import tkinter as tk
+    from tkinter import ttk
+from ttkwidgets.hook import hook_ttk_widgets, generate_hook_name, is_hooked
+
+
+class TestHooks(TestCase):
+
+    def setUp(self):
+        self.expected = {None: None}
+        self.updated = False
+        self.user_hook_called = False
+        self.second_updated = False
+
+    def basic_updater(self, widget, option, value):
+        self.assertTrue(option in self.expected)
+        self.assertEquals(value, self.expected[option])
+        self.updated = True
+
+    def second_updater(self, widget, option, value):
+        self.second_updated = True
+
+    def has_been_updated(self):
+        updated = self.updated
+        self.updated = False
+        return updated
+
+    def has_been_second_updated(self):
+        updated = self.second_updated
+        self.second_updated = False
+        return updated
+
+    def test_basic_hook(self):
+        self.expected = {"tooltip": "Hello World"}
+        options = {"tooltip": "Default Value"}
+        hook_ttk_widgets(self.basic_updater, options)
+        ttk.Button(tooltip="Hello World")
+        self.assertTrue(self.has_been_updated())
+
+        self.assertTrue(is_hooked(options))
+        self.assertTrue(hasattr(ttk.Button, generate_hook_name(options)))
+
+    def test_user_hook_and_defaults(self):
+        self.expected = {"not_user": "Hello World"}
+        hook_ttk_widgets(self.basic_updater, self.expected.copy())
+
+        button_init = ttk.Button.__init__
+
+        def __init__(self_widget, *args, **kwargs):
+            self.user_hook_called = True
+            button_init(self_widget, *args, **kwargs)
+
+        ttk.Button.__init__ = __init__
+
+        ttk.Button()
+        self.assertTrue(self.user_hook_called)
+        self.assertTrue(is_hooked(self.expected))
+        self.assertTrue(self.has_been_updated())
+
+    def test_multi_hooks(self):
+        options1 = {"hook1": "Default One"}
+        options2 = {"hook2": "Default Two"}
+        self.expected = {"hook1": "Custom One"}
+
+        name = hook_ttk_widgets(self.basic_updater, options1)
+        hook_ttk_widgets(self.second_updater, options2)
+        self.assertEquals(name, generate_hook_name(options1))
+
+        self.assertTrue(is_hooked(options1))
+        self.assertTrue(is_hooked(options2))
+
+        ttk.Button(hook1="Custom One")
+
+        self.assertTrue(is_hooked(options1))
+        self.assertTrue(is_hooked(options2))
+
+        self.assertTrue(self.has_been_updated())
+        self.assertTrue(self.has_been_second_updated())
+

--- a/tests/test_scaleentry.py
+++ b/tests/test_scaleentry.py
@@ -93,7 +93,8 @@ class TestScaleEntry(BaseWidgetTest):
                 'takefocus', 'cursor', 'style', 'class', 'scalewidth', 'orient',
                 'entrywidth', 'from', 'to', 'compound', 'entryscalepad']
         keys.sort()
-        self.assertEqual(scale.keys(), keys)
+        widget_keys = scale.keys()
+        self.assertTrue(all(key in widget_keys for key in keys))
         self.assertEqual(scale['orient'], tk.VERTICAL)
         self.assertEqual(scale['scalewidth'], 100)
         self.assertEqual(scale['entrywidth'], 4)

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -95,7 +95,8 @@ class TestTable(BaseWidgetTest):
                 'class',
                 'sortable',
                 'drag_cols']
-        self.assertEqual(sorted(table.keys()), sorted(keys))
+        widget_keys = table.keys()
+        self.assertTrue(all(key in widget_keys for key in keys))
 
         table.move('4', '', 0)
         self.assertEqual(table.get_children('')[0], '4')

--- a/tests/test_tooltips.py
+++ b/tests/test_tooltips.py
@@ -1,0 +1,53 @@
+"""
+Author: RedFantom
+License: GNU GPLv3
+Source: The ttkwidgets repository
+"""
+from unittest import TestCase
+try:
+    import Tkinter as tk
+    import ttk
+except ImportError:
+    import tkinter as tk
+    from tkinter import ttk
+from ttkwidgets.hook import is_hooked
+from ttkwidgets import tooltips
+
+
+class TestTooltipsModule(TestCase):
+    def test_hook_exists(self):
+        self.assertTrue(is_hooked(tooltips.OPTIONS))
+
+    def test_hook_works(self):
+        tooltip = "This is a great tooltip."
+        widget = ttk.Button(text="Hello World", tooltip=tooltip)
+
+        # Check the holder existence
+        holder = getattr(widget, tooltips.NAME.lower(), None)
+        self.assertIsNotNone(holder)
+        self.assertTrue(hasattr(holder, "tooltip_widget"))
+
+        # Check that the tooltip widget exists and is created with the given value
+        tooltip_widget = getattr(holder, "tooltip_widget", None)
+        self.assertIsNotNone(tooltip_widget)
+        self.assertEqual(tooltip_widget["text"], tooltip)
+
+        # Check that the text is updated when configuring the widget only
+        tooltip = "This is another great tooltip."
+        widget["tooltip"] = tooltip
+        self.assertEqual(tooltip_widget["text"], tooltip)
+        self.assertEqual(widget["tooltip"], tooltip)
+
+        # Check that the tooltip is destroyed when configured with None
+        widget["tooltip"] = None
+        tooltip_widget = getattr(holder, "tooltip_widget")
+        self.assertIsNone(tooltip_widget)
+
+        # Check that the tooltip is updated when its options are changed
+        widget.configure(tooltip_options={"headertext": "header"}, tooltip=tooltip)
+        tooltip_widget = getattr(holder, "tooltip_widget", None)
+        self.assertIsNotNone(tooltip_widget)
+        self.assertEqual(tooltip_widget["headertext"], "header")
+        self.assertEqual(tooltip_widget["text"], tooltip)
+        self.assertEqual(widget["tooltip"], tooltip)
+        self.assertEqual(widget["tooltip_options"], {"headertext": "header"})

--- a/ttkwidgets/frames/__init__.py
+++ b/ttkwidgets/frames/__init__.py
@@ -3,3 +3,9 @@
 from .scrolledframe import ScrolledFrame
 from .toggledframe import ToggledFrame
 from .tooltip import Tooltip
+
+
+def Balloon(*args, **kwargs):
+    from warnings import warn
+    warn("'Balloon' has been renamed to 'Tooltip'", DeprecationWarning, stacklevel=2)
+    return Tooltip(*args, **kwargs)

--- a/ttkwidgets/hook.py
+++ b/ttkwidgets/hook.py
@@ -2,6 +2,19 @@
 Author: RedFantom
 License: GNU GPLv3
 Source: The ttkwidgets repository
+
+This file provides a set of functions that can be used for adding
+options to all classes that inherit from ``ttk.Widget``, so `ttk.Button``,
+for example, but also every widget contained in this package.
+
+When an option is changed, an updater function is called that the
+developer creating the hook has to provide. This updater is called
+after the widget has initialized if the option is set upon
+initialization of the widget.
+
+Default values may be specified as well. For more details, see
+:meth:`hook_ttk_widgets` for more details. See :meth:`tooltip_updater`
+for a practical implementation of a hook.
 """
 try:
     import Tkinter as tk
@@ -19,6 +32,7 @@ def is_hooked(options):
 
 def generate_hook_name(options):
     # type: (dict) -> str
+    """Generate a unique name for a hook given a set of options"""
     return "WidgetHook_" + "_".join(sorted(options))
 
 
@@ -27,9 +41,27 @@ def hook_ttk_widgets(updater, options):
     """
     Create a hook in either tk.Widget or ttk.Widget to support options
 
-    :param updater: Function to update the option
+    This function works by overriding the ``__init__``, ``configure``,
+    ``config``, ``cget`` and ``keys`` functions of the ``ttk.Widget``
+    class. The original functions are stored safely inside a class
+    object created upon the ``ttk.Widget`` class, so that they can
+    still be executed when necessary.
+
+    Multiple hooks are allowed at the same time and a custom hook
+    overwriting any of the functions (as long as it is done properly)
+    does not cause any issues.
+
+    The order in which hooks are executed is not guaranteed as a stable
+    library feature.
+
+    :param updater: Function to call when an option in the given options
+        is changed. The function should support updating for all the
+        options given in the hook.
     :type updater: (widget: t(t)k.Widget, option: str, value: Any) -> None
-    :param options: A list of string options supported by the functions
+    :param options: A dictionary of options where the keys are the
+        keyword argument names and the values are their respective
+        default values. A default value must be specified for every
+        option. All option names must be allowed in valid Python syntax.
     :type options: Dict[str, Any]
     :return: Name of the attribute created to store values
     :rtype: str
@@ -50,6 +82,7 @@ def hook_ttk_widgets(updater, options):
         original_config = ttk.Widget.config
         original_configure = ttk.Widget.configure
         original_cget = ttk.Widget.cget
+        original_keys = ttk.Widget.keys
 
     # Move the OriginalFunctions class to the target class
     setattr(ttk.Widget, name, OriginalFunctions)
@@ -66,17 +99,23 @@ def hook_ttk_widgets(updater, options):
         return getattr(getattr(self, name.lower()), option, NULL)
 
     def __init__(self, *args):
+        """Catch initialization and pop all the custom options"""
         master, widget, widget_options = args
+        # Pop all the options, taking default values first
         values = options.copy()
         for (option, default) in options.items():
             value = widget_options.pop(option, default)
             values[option] = value
+        # Perform initialization of the widget
         getattr(self, name).original_init(self, master, widget, widget_options)
+        # Create an instance object to store options on
         setattr(self, name.lower(), OriginalFunctions())
+        # Set all the options only after widget init is complete
         for option, value in values.items():  # updater only called after init is done
             setter(self, option, value)
 
     def configure(self, *args, **kwargs):
+        """Catch configure to pop custom options and configure them"""
         for widget_options in args + (kwargs,):  # Loop over all sets of options available
             if widget_options is None:
                 continue
@@ -87,14 +126,22 @@ def hook_ttk_widgets(updater, options):
         return getattr(self, name).original_configure(self, *args, **kwargs)
 
     def cget(self, key):
+        """Return the value of a custom option if key is a custom option"""
         if key in options:
             return getter(self, key)
         return getattr(self, name).original_cget(self, key)
+
+    def keys(self):
+        """Return an updated list of keys with the custom options"""
+        keys = getattr(self, name).original_keys()
+        keys.extend(options.keys())
+        return keys
 
     ttk.Widget.__init__ = __init__
     ttk.Widget.configure = configure
     ttk.Widget.config = configure
     ttk.Widget.cget = cget
+    ttk.Widget.keys = keys
 
     return name
 

--- a/ttkwidgets/hook.py
+++ b/ttkwidgets/hook.py
@@ -133,7 +133,7 @@ def hook_ttk_widgets(updater, options):
 
     def keys(self):
         """Return an updated list of keys with the custom options"""
-        keys = getattr(self, name).original_keys()
+        keys = getattr(self, name).original_keys(self)
         keys.extend(options.keys())
         return keys
 

--- a/ttkwidgets/hook.py
+++ b/ttkwidgets/hook.py
@@ -78,6 +78,8 @@ def hook_ttk_widgets(updater, options):
 
     def configure(self, *args, **kwargs):
         for widget_options in args + (kwargs,):  # Loop over all sets of options available
+            if widget_options is None:
+                continue
             for option, _ in options.items():
                 current = getter(self, option)
                 value = widget_options.pop(option, current)

--- a/ttkwidgets/hook.py
+++ b/ttkwidgets/hook.py
@@ -1,0 +1,116 @@
+"""
+Author: RedFantom
+License: GNU GPLv3
+Source: The ttkwidgets repository
+"""
+try:
+    import Tkinter as tk
+    import ttk
+except ImportError:
+    import tkinter as tk
+    from tkinter import ttk
+
+
+def is_hooked(options):
+    # type: (dict) -> bool
+    """Return whether a class is hooked for the given options"""
+    return hasattr(ttk.Widget, generate_hook_name(options))
+
+
+def generate_hook_name(options):
+    # type: (dict) -> str
+    return "WidgetHook_" + "_".join(sorted(options))
+
+
+def hook_ttk_widgets(updater, options):
+    # type: (callable, dict) -> str
+    """
+    Create a hook in either tk.Widget or ttk.Widget to support options
+
+    :param updater: Function to update the option
+    :type updater: (widget: t(t)k.Widget, option: str, value: Any) -> None
+    :param options: A list of string options supported by the functions
+    :type options: Dict[str, Any]
+    :return: Name of the attribute created to store values
+    :rtype: str
+    """
+
+    assert len(options) > 0
+
+    # Create a unique name so that multiple hooks do not interfere
+    name = generate_hook_name(options)
+    # Check to see if the hook already exists
+    if hasattr(ttk.Widget, name):
+        return name  # Hook already installed
+
+    # Create a class with the original functions
+    class OriginalFunctions(object):
+        original_init = ttk.Widget.__init__
+        original_config = ttk.Widget.config
+        original_configure = ttk.Widget.configure
+        original_cget = ttk.Widget.cget
+
+    # Move the OriginalFunctions class to the target class
+    setattr(ttk.Widget, name, OriginalFunctions)
+
+    def setter(self, option, value):
+        """Store an option on the embedded object and then call updater"""
+        if value == getter(self, option):
+            return
+        setattr(getattr(self, name.lower()), option, value)
+        updater(self, option, value)
+
+    def getter(self, option):
+        """Retrieve an option value from the embedded object"""
+        return getattr(getattr(self, name.lower()), option, options[option])
+
+    def __init__(self, *args):
+        master, widget, widget_options = args
+        values = options.copy()
+        for (option, default) in options.items():
+            value = widget_options.pop(option, default)
+            values[option] = value
+        getattr(self, name).original_init(self, master, widget, widget_options)
+        setattr(self, name.lower(), OriginalFunctions())
+        for option, value in values.items():  # updater only called after init is done
+            setter(self, option, value)
+
+    def configure(self, *args, **kwargs):
+        for widget_options in args + (kwargs,):  # Loop over all sets of options available
+            for option, _ in options.items():
+                current = getter(self, option)
+                value = widget_options.pop(option, current)
+                setter(self, option, value)
+        return getattr(self, name).original_configure(self, *args, **kwargs)
+
+    def cget(self, key):
+        if key in options:
+            return getter(self, key)
+        return getattr(self, name).original_cget(self, key)
+
+    ttk.Widget.__init__ = __init__
+    ttk.Widget.configure = configure
+    ttk.Widget.config = configure
+    ttk.Widget.cget = cget
+
+    return name
+
+
+if __name__ == '__main__':
+    hook_ttk_widgets(lambda s, o, v: print(s, o, v), {"tooltip": "Default Value"})
+    hook_ttk_widgets(lambda s, o, v: print(s, o, v), {"hello_world": "second_hook"})
+
+    original_init = ttk.Button.__init__
+
+    def __init__(self, *args, **kwargs):
+        print("User custom hook")
+        original_init(self, *args, **kwargs)
+
+    ttk.Button.__init__ = __init__
+
+    window = tk.Tk()
+    button = ttk.Button(window, text="Destroy", command=window.destroy, tooltip="Destroys Window")
+    button.pack()
+    print([name for name in dir(button) if name.startswith("WidgetHook")])
+    window.after(1000, lambda: button.configure(tooltip="Does not destroy window", command=lambda: None))
+    window.mainloop()

--- a/ttkwidgets/hook.py
+++ b/ttkwidgets/hook.py
@@ -26,7 +26,7 @@ except ImportError:
 
 def is_hooked(options):
     # type: (dict) -> bool
-    """Return whether a class is hooked for any of the given options"""
+    """Return whether ``ttk.Widget`` is hooked for any of the given options"""
     for hookname in [hook for hook in dir(ttk.Widget) if hook.startswith("WidgetHook_")]:
         hookoptions = getattr(ttk.Widget, hookname).defaults
         if any(option in hookoptions for option in options):
@@ -61,7 +61,7 @@ def hook_ttk_widgets(updater, options):
     :param updater: Function to call when an option in the given options
         is changed. The function should support updating for all the
         options given in the hook.
-    :type updater: (widget: t(t)k.Widget, option: str, value: Any) -> None
+    :type updater: (widget: ttk.Widget, option: str, value: Any) -> None
     :param options: A dictionary of options where the keys are the
         keyword argument names and the values are their respective
         default values. A default value must be specified for every
@@ -151,6 +151,7 @@ def hook_ttk_widgets(updater, options):
     ttk.Widget.configure = configure
     ttk.Widget.config = configure
     ttk.Widget.cget = cget
+    ttk.Widget.__getitem__ = cget
     ttk.Widget.keys = keys
 
     return name

--- a/ttkwidgets/hook.py
+++ b/ttkwidgets/hook.py
@@ -155,23 +155,3 @@ def hook_ttk_widgets(updater, options):
     ttk.Widget.keys = keys
 
     return name
-
-
-if __name__ == '__main__':
-    hook_ttk_widgets(lambda s, o, v: print(s, o, v), {"tooltip": "Default Value"})
-    hook_ttk_widgets(lambda s, o, v: print(s, o, v), {"hello_world": "second_hook"})
-
-    original_init = ttk.Button.__init__
-
-    def __init__(self, *args, **kwargs):
-        print("User custom hook")
-        original_init(self, *args, **kwargs)
-
-    ttk.Button.__init__ = __init__
-
-    window = tk.Tk()
-    button = ttk.Button(window, text="Destroy", command=window.destroy, tooltip="Destroys Window")
-    button.pack()
-    print([name for name in dir(button) if name.startswith("WidgetHook")])
-    window.after(1000, lambda: button.configure(tooltip="Does not destroy window", command=lambda: None))
-    window.mainloop()

--- a/ttkwidgets/hook.py
+++ b/ttkwidgets/hook.py
@@ -34,6 +34,7 @@ def hook_ttk_widgets(updater, options):
     :return: Name of the attribute created to store values
     :rtype: str
     """
+    NULL = object()
 
     assert len(options) > 0
 
@@ -55,12 +56,14 @@ def hook_ttk_widgets(updater, options):
 
     def setter(self, option, value):
         """Store an option on the embedded object and then call updater"""
-        setattr(getattr(self, name.lower()), option, value)
-        updater(self, option, value)
+        current = getter(self, option)
+        if current != value:
+            setattr(getattr(self, name.lower()), option, value)
+            updater(self, option, value)
 
     def getter(self, option):
         """Retrieve an option value from the embedded object"""
-        return getattr(getattr(self, name.lower()), option, options[option])
+        return getattr(getattr(self, name.lower()), option, NULL)
 
     def __init__(self, *args):
         master, widget, widget_options = args

--- a/ttkwidgets/hook.py
+++ b/ttkwidgets/hook.py
@@ -55,8 +55,6 @@ def hook_ttk_widgets(updater, options):
 
     def setter(self, option, value):
         """Store an option on the embedded object and then call updater"""
-        if value == getter(self, option):
-            return
         setattr(getattr(self, name.lower()), option, value)
         updater(self, option, value)
 

--- a/ttkwidgets/tooltips.py
+++ b/ttkwidgets/tooltips.py
@@ -13,9 +13,6 @@ arguments upon widget initialization.
 
 The default options for the Balloon widget for the program may also be
 changed by using the update_defaults function.
-
-# TODO: Convert current implementation to a mixin
-# TODO: Apply mixin to tkWidget also
 """
 try:
     import Tkinter as tk
@@ -33,6 +30,14 @@ NAME = generate_hook_name(OPTIONS)
 
 def update_defaults(defaults):
     # type: (dict) -> None
+    """
+    Update the default options applied to the tooltip of a widget
+
+    Updating the default options of the hook is no longer possible after
+    the hook has been setup, but the :meth:`tooltip_updater` applies
+    the default options first to all tooltips and only overwrites them
+    if custom options have been given for the tooltip.
+    """
     global OPTIONS
     OPTIONS["tooltip_options"] = defaults
 
@@ -71,6 +76,7 @@ def tooltip_tooltip_updater(self, holder, tooltip_widget, tooltip):
 
 def tooltip_options_updater(self, holder, tooltip_widget, options):
     """Update the options of a tooltip widget held on a widget"""
+    # TODO: Implementation of this function
     pass
 
 

--- a/ttkwidgets/tooltips.py
+++ b/ttkwidgets/tooltips.py
@@ -5,13 +5,13 @@ Source: The ttkwidgets repository
 
 By importing this file at some point in a program, the
 ttk.Widget parent classes get dynamically mixed in with a class that
-adds the functionality of adding a tooltip (Balloon) to any widget.
+adds the functionality of adding a tooltip (Tooltip) to any widget.
 
 Tooltips are only added when a string to show in them is explicitly
-given. Options for a Balloon may be given as a dictionary of keyword
+given. Options for a Tooltip may be given as a dictionary of keyword
 arguments upon widget initialization.
 
-The default options for the Balloon widget for the program may also be
+The default options for the Tooltip widget for the program may also be
 changed by using the update_defaults function.
 """
 try:
@@ -21,7 +21,7 @@ except ImportError:
     import tkinter as tk
     from tkinter import ttk
 from ttkwidgets.hook import hook_ttk_widgets, generate_hook_name, is_hooked
-from ttkwidgets.frames import Balloon
+from ttkwidgets.frames import Tooltip
 
 
 OPTIONS = {"tooltip": None, "tooltip_options": {}}
@@ -69,14 +69,14 @@ def tooltip_options_hook(self, option, value):
 
 
 def tooltip_tooltip_updater(self, holder, tooltip_widget, tooltip):
-    # type: ((tk.Widget, ttk.Widget), object, (Balloon, None), (str, None)) -> None
+    # type: ((tk.Widget, ttk.Widget), object, (Tooltip, None), (str, None)) -> None
     """Update the ``tooltip`` option of a widget by updating tooltip text"""
     if tooltip_widget is None and tooltip is not None:
         # Create a new tooltip
         options = OPTIONS["tooltip_options"].copy()
         options.update(getattr(holder, "tooltip_options", {}))
         options["text"] = tooltip
-        tooltip_widget = Balloon(self, **options)
+        tooltip_widget = Tooltip(self, **options)
     elif tooltip_widget is not None and tooltip is None:
         # Destroy existing tooltip
         tooltip_widget.destroy()

--- a/ttkwidgets/tooltips.py
+++ b/ttkwidgets/tooltips.py
@@ -1,0 +1,87 @@
+"""
+Author: RedFantom
+License: GNU GPLv3
+Source: The ttkwidgets repository
+
+By importing this file at some point in a program, the
+ttk.Widget parent classes get dynamically mixed in with class that
+adds the functionality of adding a tooltip (Balloon) to any widget.
+
+Tooltips are only added when a string to show in them is explicitly
+given. Options for a Balloon may be given as a dictionary of keyword
+arguments upon widget initialization.
+
+The default options for the Balloon widget for the program may also be
+changed by using the update_defaults function.
+
+# TODO: Convert current implementation to a mixin
+# TODO: Apply mixin to tkWidget also
+"""
+try:
+    import Tkinter as tk
+    import ttk
+except ImportError:
+    import tkinter as tk
+    from tkinter import ttk
+from ttkwidgets.frames import Balloon
+
+
+DEFAULTS = {}
+
+
+def update_defaults(defaults):
+    # type: (dict) -> None
+    global DEFAULTS
+    DEFAULTS.update(defaults)
+
+
+class ToolTippableWidget(ttk.Widget):
+    def __init__(self, *args):
+        master, widget_type, kwargs = args
+        self._tooltip = kwargs.pop("tooltip", None)
+        self._tooltip_options = DEFAULTS.copy()
+        self._tooltip_options.update(kwargs.pop("tooltip_options", {}))
+        ttk.Widget._init__original(self, master, widget_type, kwargs)
+        self.__widget = None
+        self._update_tooltip()
+
+    def configure(self, *args, **kwargs):
+        self._tooltip = kwargs.pop("tooltip", None)
+        self._tooltip_options.update(kwargs.pop("tooltip_options", {}))
+        self._update_tooltip()
+        return ttk.Widget._configure_original(self, *args, **kwargs)
+
+    def cget(self, key):
+        if key == "tooltip":
+            return self._tooltip
+        elif key == "tooltip_options":
+            return self._tooltip_options
+        return ttk.Widget._cget_original(self, key)
+
+    def config(self, *args, **kwargs):
+        return self.configure(*args, **kwargs)
+
+    def _update_tooltip(self):
+        self._tooltip_options["text"] = self._tooltip
+        if self._tooltip is None and self.__widget is not None:
+            self.__widget.destroy()
+        elif self._tooltip is not None and self.__widget is not None:
+            self.__widget.configure(**self._tooltip_options)
+        elif not isinstance(self, Balloon):  # Balloons may not have Balloons -> recursion
+            self.__widget = Balloon(self, **self._tooltip_options)
+
+
+if ttk.Widget.__init__ is not ToolTippableWidget.__init__:
+
+    # Save the original functions
+    ttk.Widget._init__original = ttk.Widget.__init__
+    ttk.Widget._configure_original = ttk.Widget.configure
+    ttk.Widget._config_original = ttk.Widget.config
+    ttk.Widget._cget_original = ttk.Widget.cget
+
+    # Apply the modified functions
+    ttk.Widget.__init__ = ToolTippableWidget.__init__
+    ttk.Widget.configure = ToolTippableWidget.configure
+    ttk.Widget.config = ToolTippableWidget.config
+    ttk.Widget.cget = ToolTippableWidget.cget
+    ttk.Widget._update_tooltip = ToolTippableWidget._update_tooltip


### PR DESCRIPTION
This branch contains two new modules, `hook.py` and `tooltips.py`, which together allow adding two keyword arguments, `tooltip` and `tooltip_options`, to all widgets derived from `ttk.Widget`. These keyword arguments may be used to automatically create `Balloon`s for all widgets upon their initialization. For details on how this is done, please see the `hook.py` docstrings.

This PR is marked pending, meaning that it is not ready for merging yet. However, I would still like some feedback upon the implementation. Right now, the following tests are implemented:
- Creation of a single hook
- Creation of multiple hooks
- Testing of default options
- Custom hooking by overwriting `__init__` from elsewhere

Tests that should still be implemented:
- [x] Multi-option hooks
- [x] Attempting to overwrite a hook of the same options
- [x] Verifying cget, configure and keys of hooked widgets

Miscellaneous:
- [x] `AUTHORS.md` entry
- [x] sphinx documentation entry
- [x] unittests for the `tooltips.py` module
- [x] Implementation of tooltips option updater function


