### PR TITLE
 Merge tkinterpp-debounce into tkinterpp-merger to add DebouncedFrame, DebouncedToplevel, DebouncedTk

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "python.linting.enabled": true,
+    "python.linting.pylintEnabled": true
+}

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -29,5 +29,6 @@ This file contains a list of all the authors of widgets in this repository. Plea
   * `get_bitmap`
   * `PopupMenu`
   * `DirTree`
+  * `DebouncedFrame`, `DebouncedTk` and `DebouncedToplevel`
 - Multiple authors:
   * `ScaleEntry` (RedFantom and Juliette Monsel)

--- a/examples/example_debounce.py
+++ b/examples/example_debounce.py
@@ -1,0 +1,44 @@
+import tkinter as tk
+from ttkwidgets import DebouncedFrame
+
+
+def instance_press(event):
+    print("instance_press:\t%s\t%s" % (event.widget, event.keysym))
+
+def instance_release(event):
+    print("instance_release:\t%s\t%s" % (event.widget, event.keysym))
+
+def class_press(event):
+    print("class_press:\t%s\t%s" % (event.widget, event.keysym))
+
+def class_release(event):
+    print("class_release:\t%s\t%s" % (event.widget, event.keysym))
+
+def all_press(event):
+    print("all_press:\t%s\t%s" % (event.widget, event.keysym))
+
+def all_release(event):
+    print("all_release:\t%s\t%s" % (event.widget, event.keysym))
+
+root = tk.Tk()
+frame = DebouncedFrame(root, width=100, height=100, bg='red', takefocus=True)
+frame2 = DebouncedFrame(root, width=100, height=100, bg='blue', takefocus=True)
+frame.bind("<KeyPress-a>", instance_press, False)
+frame.bind("<KeyRelease-a>", instance_release, False)
+frame.bind("<KeyPress-s>", instance_press)
+frame.bind("<KeyRelease-s>", instance_release)
+
+frame.bind_class("<KeyPress-d>", class_press)
+frame.bind_class("<KeyRelease-d>", class_release)
+
+frame.bind_all('<KeyPress-F1>', all_press)
+frame.bind_all('<KeyRelease-F1>', all_release)
+
+frame2.bind("<KeyPress-f>", instance_press)
+frame2.bind("<KeyRelease-f>", instance_release)
+
+frame.pack()
+frame2.pack()
+frame.focus_set()
+
+root.mainloop()

--- a/tests/test_debounce.py
+++ b/tests/test_debounce.py
@@ -1,0 +1,35 @@
+# Copyright (c) Dogeek 2019
+# For license see LICENSE
+
+from ttkwidgets import DebouncedFrame
+from tests import BaseWidgetTest
+import tkinter as tk
+
+
+class TestDebouncedFrame(BaseWidgetTest):
+    def test_calendar_init(self):
+        widget = DebouncedFrame(self.window)
+        widget.pack()
+        self.window.update()
+
+    def test_debouncer_bind_instance(self):
+        widget = DebouncedFrame(self.window)
+        widget.pack()
+        widget.bind("<KeyPress-i>", lambda evt: None, True)
+        widget.bind("<KeyRelease-i>", lambda evt: None, True)
+
+    def test_debouncer_bind_class(self):
+        widget = DebouncedFrame(self.window)
+        widget.pack()
+        widget.bind_class("<KeyPress-c>", lambda evt: None, True)
+        widget.bind_class("<KeyRelease-c>", lambda evt: None, True)
+
+    def test_debouncer_bind_all(self):
+        widget = DebouncedFrame(self.window)
+        widget.pack()
+        widget.bind_all("<KeyPress-a>", lambda evt: None, True)
+        widget.bind_all("<KeyRelease-a>", lambda evt: None, True)
+
+    def test_debouncedframe_kw(self):
+        widget = DebouncedFrame(self.window, width=100, height=100)
+        widget.pack()

--- a/ttkwidgets/__init__.py
+++ b/ttkwidgets/__init__.py
@@ -15,3 +15,5 @@ from ttkwidgets.popupmenu import PopupMenu
 from ttkwidgets.dirtreewidget import DirTree
 
 from ttkwidgets.errors import TtkWidgetsError, I18NError, AssetNotFoundError, AssetMaskNotFoundError
+
+from ttkwidgets.frames import DebouncedFrame, DebouncedTk, DebouncedToplevel

--- a/ttkwidgets/frames/__init__.py
+++ b/ttkwidgets/frames/__init__.py
@@ -3,3 +3,4 @@
 from .scrolledframe import ScrolledFrame
 from .toggledframe import ToggledFrame
 from .balloon import Balloon
+from .debounce import DebouncedFrame, DebouncedTk, DebouncedToplevel, _Debounce

--- a/ttkwidgets/frames/debounce.py
+++ b/ttkwidgets/frames/debounce.py
@@ -86,7 +86,7 @@ class _Debounce:
         # this will be used for underlying bind methods
         if not hasattr(self, '_base'):
             for base in self.__class__.__bases__:
-                if base.__name__ != 'Debounce':
+                if base.__name__ != '_Debounce':
                     self._base = base
                     break
         # for instance bindings

--- a/ttkwidgets/frames/debounce.py
+++ b/ttkwidgets/frames/debounce.py
@@ -1,0 +1,216 @@
+import tkinter as tk
+import tkinter.ttk as ttk
+
+
+class _Debounce:
+    """
+    When holding a key down, multiple key press and key release events are fired in
+    succession. Debouncing is implemented in order to squash these repeated events
+    and know when the "real" KeyRelease and KeyPress events happen.
+    Use by subclassing a tkinter widget along with this class:
+        class DebounceTk(Debounce, tk.Tk):
+            pass
+    """
+
+    # use classname as key to store class bindings
+    # as single dict for all instances
+    _bind_class_dict = {}
+
+    # 'all' bindings stored here
+    # single dict for all instances
+    _bind_all_dict = {}
+
+    def bind(self, event, function, debounce=True):
+        """
+        Override the bind method, acts as normal binding if not KeyPress or KeyRelease
+        type events, optional debounce parameter can be set to false to force normal behavior
+        """
+        self._debounce_init()
+        self._debounce_bind(event, function, debounce,
+                            self._binding_dict, self._base.bind)
+
+    def bind_all(self, event, function, debounce=True):
+        """
+        Override the bind_all method, acts as normal binding if not KeyPress or KeyRelease
+        type events, optional debounce parameter can be set to false to force normal behavior
+        """
+        self._debounce_init()
+        self._debounce_bind(event, function, debounce,
+                            self._bind_all_dict, self._base.bind_all)
+
+    def bind_class(self, event, function, debounce=True):
+        """
+        Override the bind_class method, acts as normal binding if not KeyPress or KeyRelease
+        type events, optional debounce parameter can be set to false to force normal behavior
+        unlike underlying tk bind_class this uses name of class on which its called
+        instead of requireing clas name as a parameter
+        """
+        self._debounce_init()
+        self._debounce_bind(event, function, debounce,
+                            self._bind_class_dict[self.__class__.__name__],
+                            self._base.bind_class, self.__class__.__name__)
+
+    def _debounce_bind(self, event, function, debounce, bind_dict, bind_method, *args):
+        """
+        internal method to implement binding
+        """
+        self._debounce_init()
+        # remove special symbols and split at first hyphen if present
+        ev = event.replace("<", "").replace(">", "").split('-', 1)
+        # if debounce and a supported event
+        if (('KeyPress' in ev) or ('KeyRelease' in ev)) and debounce:
+            if len(ev) == 2:  # not generic binding so use keynames as key
+                evname = ev[1]
+            else:  # generic binding, use event type
+                evname = ev[0]
+            if evname in bind_dict: # if have prev binding use that dict
+                d = bind_dict[evname]
+            else:  # no previous binding, create new default dict
+                d = {'has_prev_key_release': None, 'has_prev_key_press': False}
+
+            # add function to dict (as keypress or release depending on name)
+            d[ev[0]] = function
+            # save binding back into dict
+            bind_dict[evname] = d
+            # call base class binding
+            if ev[0] == 'KeyPress':
+                bind_method(self, *args, sequence=event, func=self._on_key_press_repeat)
+            elif ev[0] == 'KeyRelease':
+                bind_method(self, *args, sequence=event, func=self._on_key_release_repeat)
+
+        else:  # not supported or not debounce, bind as normal
+            bind_method(self, *args, sequence=event, func=function)
+
+    def _debounce_init(self):
+        # get first base class that isn't Debounce and save ref
+        # this will be used for underlying bind methods
+        if not hasattr(self, '_base'):
+            for base in self.__class__.__bases__:
+                if base.__name__ != 'Debounce':
+                    self._base = base
+                    break
+        # for instance bindings
+        if not hasattr(self, '_binding_dict'):
+            self._binding_dict = {}
+
+        # for class bindings
+        try:  # check if this class has alread had class bindings
+            self._bind_class_dict[self.__class__.__name__]
+        except KeyError:  # create dict to store if not
+            self._bind_class_dict[self.__class__.__name__] = {}
+
+        # get the current bind tags
+        bindtags = list(self.bindtags())
+        # add our custom bind tag before the origional bind tag
+        index = bindtags.index(self._base.__name__)
+        bindtags.insert(index, self.__class__.__name__)
+        # save the bind tags back to the widget
+        self.bindtags(tuple(bindtags))
+
+    def _get_evdict(self, event):
+        """
+        internal method used to get the dictionaries that store the special binding info
+        """
+        dicts = []
+        names = {'2': 'KeyPress', '3': 'KeyRelease'}
+        # loop through all applicable bindings
+        for d in [self._binding_dict,  # instance binding
+                  self._bind_class_dict[self.__class__.__name__],  # class
+                  self._bind_all_dict]:  # all
+            evdict = None
+            generic = False
+            if event.type in names:  # if supported event
+                evname = event.keysym
+                if evname not in d:  # if no specific binding
+                    generic = True
+                    evname = names[event.type]
+                try:
+                    evdict = d[evname]
+                except KeyError:
+                    pass
+            if evdict:  # found a binding
+                dicts.append((d, evdict, generic))
+        return dicts
+
+    def _on_key_release(self, event):
+        """
+        internal method, called by _on_key_release_repeat only when key is actually released
+        this then calls the method that was passed in to the bind method
+        """
+        # get all binding details
+        for d, evdict, generic in self._get_evdict(event):
+            # call callback
+            res = evdict['KeyRelease'](event)
+            evdict['has_prev_key_release'] = None
+
+            # record that key was released
+            if generic:
+                d['KeyPress'][event.keysym] = False
+            else:
+                evdict['has_prev_key_press'] = False
+            # if supposed to break propagate this up
+            if res == 'break':
+                return 'break'
+
+    def _on_key_release_repeat(self, event):
+        """
+        internal method, called by the 'KeyRelease' event, used to filter false events
+        """
+        # get all binding details
+        for d, evdict, generic in self._get_evdict(event):
+            if evdict["has_prev_key_release"]:
+                # got a previous release so cancel it
+                self.after_cancel(evdict["has_prev_key_release"])
+                evdict["has_prev_key_release"] = None
+            # queue new event for key release
+            evdict["has_prev_key_release"] = self.after_idle(self._on_key_release, event)
+
+    def _on_key_press(self, event):
+        """
+        internal method, called by _on_key_press_repeat only when key is actually pressed
+        this then calls the method that was passed in to the bind method
+        """
+        # get all binding details
+        for d, evdict, generic in self._get_evdict(event):
+            # call callback
+            res = evdict['KeyPress'](event)
+            # record that key was pressed
+            if generic:
+                evdict[event.keysym] = True
+            else:
+                evdict['has_prev_key_press'] = True
+            # if supposed to break propagate this up
+            if res == 'break':
+                return 'break'
+
+    def _on_key_press_repeat(self, event):
+        """
+        internal method, called by the 'KeyPress' event, used to filter false events
+        """
+        # get binding details
+        for _, evdict, generic in self._get_evdict(event):
+            if not generic:
+                if evdict["has_prev_key_release"]:
+                    # got a previous release so cancel it
+                    self.after_cancel(evdict["has_prev_key_release"])
+                    evdict["has_prev_key_release"] = None
+                else:
+                    # if not pressed before (real event)
+                    if not evdict['has_prev_key_press']:
+                        self._on_key_press(event)
+            else:
+                # if not pressed before (real event)
+                if (event.keysym not in evdict) or (not evdict[event.keysym]):
+                    self._on_key_press(event)
+
+
+class DebouncedTk(_Debounce, tk.Tk):
+    pass
+
+
+class DebouncedToplevel(_Debounce, tk.Toplevel):
+    pass
+
+
+class DebouncedFrame(_Debounce, ttk.Frame):
+    pass


### PR DESCRIPTION
### PR Details:
- Widget name: DebouncedFrame, DebouncedToplevel, DebouncedTk
- Author: Dogeek

### Description
Debounced Frame, Toplevel and Tk are used in place of regular Frame, Toplevel and Tk in order to fix the current behavior of event binding, and key repeat functionnality.

The default behavior on key repeat event firings is:

- KeyPress, KeyRelease, KeyPress, KeyRelease ...

The Debounced version :

- KeyPress, KeyPress, KeyPress, KeyPress ... KeyRelease

### Checklist
- [x] Widget in a separate file in the appropriate folder
- [x] Widget functions properly on both Windows and Linux
- [x] Widget code includes docstrings with parameter descriptions
- [x] Included an example file in `/examples`
- [x] Widget is covered by unitttests in `/tests`
- [x] Widget includes required assets files
- [x] Reference to widget in `AUTHORS.md`
- [ ] Entry in sphinx documentation
