### PR TITLE
Merge python3 into master to remove Python 2 support

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,9 +1,10 @@
 environment:
   matrix:
-    - PYTHON: "C:\\PYTHON27"
     - PYTHON: "C:\\PYTHON34"
     - PYTHON: "C:\\PYTHON35"
     - PYTHON: "C:\\PYTHON36"
+    - PYTHON: "C:\\PYTHON37"
+    - PYTHON: "C:\\PYTHON38"
 install:
   - "%PYTHON%\\python.exe -m pip install codecov coverage nose mock pynput"
 build: off

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: python
 required: sudo
 python:
-  - "2.7"
   - "3.5"
   - "3.6"
   - "3.7"
+  - "3.8"
 before_install:
   - "export DISPLAY=:99.0"
   - sudo systemctl start xvfb

--- a/examples/example_askcolor.py
+++ b/examples/example_askcolor.py
@@ -4,12 +4,8 @@
 # For license see LICENSE
 
 from ttkwidgets.color import askcolor
-try:
-    import Tkinter as tk
-    import ttk
-except ImportError:
-    import tkinter as tk
-    from tkinter import ttk
+import tkinter as tk
+from tkinter import ttk
 from PIL import Image, ImageTk
 
 

--- a/examples/example_askfont.py
+++ b/examples/example_askfont.py
@@ -4,12 +4,8 @@
 # For license see LICENSE
 
 from ttkwidgets.font import askfont
-try:
-    import Tkinter as tk
-    import ttk
-except ImportError:
-    import tkinter as tk
-    from tkinter import ttk
+import tkinter as tk
+from tkinter import ttk
 
 def font():
     res = askfont()

--- a/examples/example_autocompletecombobox.py
+++ b/examples/example_autocompletecombobox.py
@@ -4,10 +4,7 @@
 # For license see LICENSE
 
 from ttkwidgets.autocomplete import AutocompleteCombobox
-try:
-    import Tkinter as tk
-except ImportError:
-    import tkinter as tk
+import tkinter as tk
 
 window = tk.Tk()
 tk.Label(window, text="Combobox with autocompletion for the Tk instance's methods:").pack(side='left')

--- a/examples/example_autocompleteentry.py
+++ b/examples/example_autocompleteentry.py
@@ -4,10 +4,7 @@
 # For license see LICENSE
 
 from ttkwidgets.autocomplete import AutocompleteEntry
-try:
-    import Tkinter as tk
-except ImportError:
-    import tkinter as tk
+import tkinter as tk
 
 window = tk.Tk()
 tk.Label(window, text="Entry with autocompletion for the Tk instance's methods:").pack(side='left')

--- a/examples/example_autocompleteentrylistbox.py
+++ b/examples/example_autocompleteentrylistbox.py
@@ -2,10 +2,7 @@
 
 # Copyright (c) Juliette Monsel 2019
 # For license see LICENSE
-try:
-    import Tkinter as tk
-except ImportError:
-    import tkinter as tk
+import tkinter as tk
 from ttkwidgets.autocomplete import AutocompleteEntryListbox
 
 window = tk.Tk()

--- a/examples/example_autohidescrollbar.py
+++ b/examples/example_autohidescrollbar.py
@@ -4,10 +4,7 @@
 # For license see LICENSE
 
 from ttkwidgets import AutoHideScrollbar
-try:
-    import Tkinter as tk
-except ImportError:
-    import tkinter as tk
+import tkinter as tk
 
 window = tk.Tk()
 listbox = tk.Listbox(window, height=5)

--- a/examples/example_balloon.py
+++ b/examples/example_balloon.py
@@ -3,12 +3,8 @@
 # Copyright (c) RedFantom 2017
 # For license see LICENSE
 from ttkwidgets.frames import Balloon
-try:
-    import Tkinter as tk
-    import ttk
-except ImportError:
-    import tkinter as tk
-    from tkinter import ttk
+import tkinter as tk
+from tkinter import ttk
 
 
 window = tk.Tk()

--- a/examples/example_calendar.py
+++ b/examples/example_calendar.py
@@ -4,10 +4,7 @@
 # For license see LICENSE
 
 from ttkwidgets import Calendar
-try:
-    import Tkinter as tk
-except ImportError:
-    import tkinter as tk
+import tkinter as tk
 
 def validate():
     sel = calendar.selection

--- a/examples/example_checkboxtreeview.py
+++ b/examples/example_checkboxtreeview.py
@@ -4,10 +4,7 @@
 # For license see LICENSE
 
 from ttkwidgets import CheckboxTreeview
-try:
-    import Tkinter as tk
-except ImportError:
-    import tkinter as tk
+import tkinter as tk
 
 root = tk.Tk()
 

--- a/examples/example_debugwindow.py
+++ b/examples/example_debugwindow.py
@@ -5,12 +5,8 @@
 # For license see LICENSE
 
 from ttkwidgets import DebugWindow
-try:
-    import Tkinter as tk
-    import ttk
-except ImportError:
-    import tkinter as tk
-    from tkinter import ttk
+import tkinter as tk
+from tkinter import ttk
 
 root = tk.Tk()
 ttk.Button(root, text="Print ok", command=lambda: print('ok')).pack()

--- a/examples/example_fontselectframe.py
+++ b/examples/example_fontselectframe.py
@@ -4,12 +4,8 @@
 # For license see LICENSE
 
 from ttkwidgets.font import FontSelectFrame
-try:
-    import Tkinter as tk
-    import ttk
-except ImportError:
-    import tkinter as tk
-    from tkinter import ttk
+import tkinter as tk
+from tkinter import ttk
 
 def update_preview(font_tuple):
     print(font_tuple)

--- a/examples/example_itemscanvas.py
+++ b/examples/example_itemscanvas.py
@@ -3,12 +3,8 @@
 # Copyright (c) RedFantom 2017
 # For license see LICENSE
 from ttkwidgets import ItemsCanvas
-try:
-    import Tkinter as tk
-    import ttk
-except ImportError:
-    import tkinter as tk
-    from tkinter import ttk
+import tkinter as tk
+from tkinter import ttk
 
 
 root = tk.Tk()

--- a/examples/example_linklabel.py
+++ b/examples/example_linklabel.py
@@ -5,10 +5,7 @@
 # For license see LICENSE
 
 from ttkwidgets import LinkLabel
-try:
-    import Tkinter as tk
-except ImportError:
-    import tkinter as tk
+import tkinter as tk
 
 window = tk.Tk()
 LinkLabel(window, text="ttkwidgets repository",

--- a/examples/example_scaleentry.py
+++ b/examples/example_scaleentry.py
@@ -4,10 +4,7 @@
 # For license see LICENSE
 
 from ttkwidgets import ScaleEntry
-try:
-    import Tkinter as tk
-except ImportError:
-    import tkinter as tk
+import tkinter as tk
 
 
 window = tk.Tk()

--- a/examples/example_scrolledframe.py
+++ b/examples/example_scrolledframe.py
@@ -4,12 +4,8 @@
 # For license see LICENSE
 
 from ttkwidgets.frames import ScrolledFrame
-try:
-    import Tkinter as tk
-    import ttk
-except ImportError:
-    import tkinter as tk
-    from tkinter import ttk
+import tkinter as tk
+from tkinter import ttk
 
 window = tk.Tk()
 frame = ScrolledFrame(window, compound=tk.RIGHT, canvasheight=200)

--- a/examples/example_scrolledlistbox.py
+++ b/examples/example_scrolledlistbox.py
@@ -4,10 +4,7 @@
 # For license see LICENSE
 
 from ttkwidgets import ScrolledListbox
-try:
-    import Tkinter as tk
-except ImportError:
-    import tkinter as tk
+import tkinter as tk
 
 window = tk.Tk()
 listbox = ScrolledListbox(window, height=5)

--- a/examples/example_table.py
+++ b/examples/example_table.py
@@ -4,12 +4,8 @@
 # For license see LICENSE
 
 from ttkwidgets import Table
-try:
-    import Tkinter as tk
-    import ttk
-except ImportError:
-    import tkinter as tk
-    from tkinter import ttk
+import tkinter as tk
+from tkinter import ttk
 
 root = tk.Tk()
 

--- a/examples/example_tickscale.py
+++ b/examples/example_tickscale.py
@@ -3,12 +3,8 @@
 # Copyright (c) Juliette Monsel 2017
 # For license see LICENSE
 from ttkwidgets import TickScale
-try:
-    import Tkinter as tk
-    import ttk
-except ImportError:
-    import tkinter as tk
-    from tkinter import ttk
+import tkinter as tk
+from tkinter import ttk
 
 
 root = tk.Tk()

--- a/examples/example_toggledframe.py
+++ b/examples/example_toggledframe.py
@@ -4,12 +4,8 @@
 # For license see LICENSE
 
 from ttkwidgets.frames import ToggledFrame
-try:
-    import Tkinter as tk
-    import ttk
-except ImportError:
-    import tkinter as tk
-    from tkinter import ttk
+import tkinter as tk
+from tkinter import ttk
 
 window = tk.Tk()
 frame = ToggledFrame(window, text="Value", width=10)

--- a/tests/base_widget_testcase.py
+++ b/tests/base_widget_testcase.py
@@ -1,10 +1,7 @@
 # Copyright (c) RedFantom 2017
 # For license see LICENSE
 import unittest
-try:
-    import Tkinter as tk
-except ImportError:
-    import tkinter as tk
+import tkinter as tk
 
 
 class BaseWidgetTest(unittest.TestCase):

--- a/tests/test_autocompleteentrylistbox.py
+++ b/tests/test_autocompleteentrylistbox.py
@@ -2,10 +2,7 @@
 # For license see LICENSE
 from ttkwidgets.autocomplete import AutocompleteEntryListbox
 from tests import BaseWidgetTest
-try:
-    import Tkinter as tk
-except ImportError:
-    import tkinter as tk
+import tkinter as tk
 
 
 class TestEvent(object):

--- a/tests/test_autocompletewidgets.py
+++ b/tests/test_autocompletewidgets.py
@@ -2,10 +2,7 @@
 # For license see LICENSE
 from ttkwidgets.autocomplete import AutocompleteCombobox, AutocompleteEntry
 from tests import BaseWidgetTest
-try:
-    import Tkinter as tk
-except ImportError:
-    import tkinter as tk
+import tkinter as tk
 
 
 class TestEvent(object):

--- a/tests/test_balloon.py
+++ b/tests/test_balloon.py
@@ -2,10 +2,7 @@
 # For license see LICENSE
 from ttkwidgets.frames import Balloon
 from tests import BaseWidgetTest
-try:
-    import Tkinter as tk
-except ImportError:
-    import tkinter as tk
+import tkinter as tk
 from time import sleep
 
 

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -3,10 +3,7 @@
 from ttkwidgets import Calendar
 from tests import BaseWidgetTest
 import calendar
-try:
-    import Tkinter as tk
-except ImportError:
-    import tkinter as tk
+import tkinter as tk
 
 
 class TestCalendar(BaseWidgetTest):

--- a/tests/test_color_widgets.py
+++ b/tests/test_color_widgets.py
@@ -2,10 +2,7 @@
 # For license see LICENSE
 from tests import BaseWidgetTest
 import unittest
-try:
-    import Tkinter as tk
-except ImportError:
-    import tkinter as tk
+import tkinter as tk
 from ttkwidgets import color
 import ttkwidgets.color.functions as tkf
 

--- a/tests/test_debugwindow.py
+++ b/tests/test_debugwindow.py
@@ -3,10 +3,7 @@
 from ttkwidgets import DebugWindow
 from tests import BaseWidgetTest
 import mock
-try:
-    import Tkinter as tk
-except ImportError:
-    import tkinter as tk
+import tkinter as tk
 import os
 import sys
 

--- a/tests/test_font_widgets.py
+++ b/tests/test_font_widgets.py
@@ -2,12 +2,8 @@
 # For license see LICENSE
 from ttkwidgets.font import FontChooser, FontSelectFrame
 from tests import BaseWidgetTest
-try:
-    import Tkinter as tk
-    import tkFont as font
-except ImportError:
-    import tkinter as tk
-    from tkinter import font
+import tkinter as tk
+from tkinter import font
 import os
 
 

--- a/tests/test_itemscanvas.py
+++ b/tests/test_itemscanvas.py
@@ -6,10 +6,7 @@ from ttkwidgets.utilities import get_assets_directory
 import os
 from PIL import Image, ImageTk
 
-try:
-    import Tkinter as tk
-except ImportError:
-    import tkinter as tk
+import tkinter as tk
 from pynput.mouse import Controller, Button
 
 

--- a/tests/test_linklabel.py
+++ b/tests/test_linklabel.py
@@ -2,10 +2,7 @@
 # For license see LICENSE
 from ttkwidgets import LinkLabel
 from tests import BaseWidgetTest
-try:
-    import Tkinter as tk
-except ImportError:
-    import tkinter as tk
+import tkinter as tk
 
 
 class TestLinkLabel(BaseWidgetTest):

--- a/tests/test_scaleentry.py
+++ b/tests/test_scaleentry.py
@@ -2,10 +2,7 @@
 # For license see LICENSE
 from ttkwidgets import ScaleEntry
 from tests import BaseWidgetTest
-try:
-    import Tkinter as tk
-except ImportError:
-    import tkinter as tk
+import tkinter as tk
 
 
 class TestScaleEntry(BaseWidgetTest):

--- a/tests/test_scrolledframe.py
+++ b/tests/test_scrolledframe.py
@@ -2,10 +2,7 @@
 # For license see LICENSE
 from ttkwidgets.frames import ScrolledFrame
 from tests import BaseWidgetTest
-try:
-    import Tkinter as tk
-except ImportError:
-    import tkinter as tk
+import tkinter as tk
 
 
 class TestScrolledFrame(BaseWidgetTest):

--- a/tests/test_scrolledlistbox.py
+++ b/tests/test_scrolledlistbox.py
@@ -3,10 +3,7 @@
 from ttkwidgets import ScrolledListbox
 from tests import BaseWidgetTest
 
-try:
-    import Tkinter as tk
-except ImportError:
-    import tkinter as tk
+import tkinter as tk
 
 
 class TestScrolledListBox(BaseWidgetTest):

--- a/tests/test_tickscale.py
+++ b/tests/test_tickscale.py
@@ -2,12 +2,8 @@
 # For license see LICENSE
 from ttkwidgets import TickScale
 from tests import BaseWidgetTest
-try:
-    import Tkinter as tk
-    import ttk
-except ImportError:
-    import tkinter as tk
-    from tkinter import ttk
+import tkinter as tk
+from tkinter import ttk
 
 
 class TestTickScale(BaseWidgetTest):

--- a/tests/test_tickscale.py
+++ b/tests/test_tickscale.py
@@ -50,7 +50,7 @@ class TestTickScale(BaseWidgetTest):
                 'tickinterval',
                 'showvalue',
                 'digits']
-        self.assertEqual(sorted(scale.keys()), sorted(keys))
+        self.assertTrue(all(key in scale.keys() for key in keys))
 
         scale.config(from_=-1)
         self.window.update()

--- a/tests/test_timeline.py
+++ b/tests/test_timeline.py
@@ -2,10 +2,7 @@
 # For license see LICENSE
 from ttkwidgets import TimeLine
 from tests import BaseWidgetTest
-try:
-    import Tkinter as tk
-except ImportError:
-    import tkinter as tk
+import tkinter as tk
 
 
 class TestTimeLine(BaseWidgetTest):

--- a/tests/test_toggledframe.py
+++ b/tests/test_toggledframe.py
@@ -2,10 +2,7 @@
 # For license see LICENSE
 from ttkwidgets.frames import ToggledFrame
 from tests import BaseWidgetTest
-try:
-    import Tkinter as tk
-except ImportError:
-    import tkinter as tk
+import tkinter as tk
 
 
 class TestToggledFrame(BaseWidgetTest):

--- a/ttkwidgets/autocomplete/autocomplete_entry.py
+++ b/ttkwidgets/autocomplete/autocomplete_entry.py
@@ -5,12 +5,8 @@ Source: https://mail.python.org/pipermail/tkinter-discuss/2012-January/003041.ht
 
 Edited by RedFantom for ttk and Python 2 and 3 cross-compatibility and <Enter> binding
 """
-try:
-    import Tkinter as tk
-    import ttk
-except ImportError:
-    import tkinter as tk
-    from tkinter import ttk
+import tkinter as tk
+from tkinter import ttk
 
 tk_umlauts = ['odiaeresis', 'adiaeresis', 'udiaeresis', 'Odiaeresis', 'Adiaeresis', 'Udiaeresis', 'ssharp']
 

--- a/ttkwidgets/autocomplete/autocomplete_entrylistbox.py
+++ b/ttkwidgets/autocomplete/autocomplete_entrylistbox.py
@@ -3,12 +3,8 @@ Author: Juliette Monsel
 License: GNU GPLv3
 Source: This repository
 """
-try:
-    import Tkinter as tk
-    import ttk
-except ImportError:
-    import tkinter as tk
-    from tkinter import ttk
+import tkinter as tk
+from tkinter import ttk
 from ttkwidgets import AutoHideScrollbar
 
 

--- a/ttkwidgets/autocomplete/autocompletecombobox.py
+++ b/ttkwidgets/autocomplete/autocompletecombobox.py
@@ -7,12 +7,8 @@ Edited by RedFantom for ttk and Python 2 and 3 cross-compatibility and <Enter> b
 Edited by Juliette Monsel to include Tcl code to navigate the dropdown by Pawel Salawa
 (https://wiki.tcl-lang.org/page/ttk%3A%3Acombobox, copyright 2011)
 """
-try:
-    import Tkinter as tk
-    import ttk
-except ImportError:
-    import tkinter as tk
-    from tkinter import ttk
+import tkinter as tk
+from tkinter import ttk
 
 tk_umlauts = ['odiaeresis', 'adiaeresis', 'udiaeresis', 'Odiaeresis', 'Adiaeresis', 'Udiaeresis', 'ssharp']
 

--- a/ttkwidgets/autohidescrollbar.py
+++ b/ttkwidgets/autohidescrollbar.py
@@ -5,10 +5,7 @@ Source: This repository
 """
 # Based on an idea by Fredrik Lundh (effbot.org/zone/tkinter-autoscrollbar.htm)
 # adapted to support all layouts
-try:
-    import ttk
-except ImportError:
-    from tkinter import ttk
+from tkinter import ttk
 
 
 class AutoHideScrollbar(ttk.Scrollbar):

--- a/ttkwidgets/calendarwidget.py
+++ b/ttkwidgets/calendarwidget.py
@@ -3,14 +3,9 @@ Author: The Python Team
 License: The Python License
 Source: http://svn.python.org/projects/sandbox/trunk/ttk-gsoc/samples/ttkcalendar.py
 """
-try:
-    import Tkinter as tk
-    import ttk
-    import tkFont
-except ImportError:
-    import tkinter as tk
-    from tkinter import ttk
-    from tkinter import font as tkFont
+import tkinter as tk
+from tkinter import ttk
+from tkinter import font
 import calendar
 
 
@@ -124,14 +119,14 @@ class Calendar(ttk.Frame):
         self._calendar.tag_configure('header', background='grey90')
         self._calendar.insert('', 'end', values=cols, tag='header')
         # adjust its columns width
-        font = tkFont.Font()
+        font = font.Font()
         maxwidth = max(font.measure(col) for col in cols)
         for col in cols:
             self._calendar.column(col, width=maxwidth, minwidth=maxwidth,
                                   anchor='e')
 
     def __setup_selection(self, sel_bg, sel_fg):
-        self._font = tkFont.Font()
+        self._font = font.Font()
         self._canvas = canvas = tk.Canvas(self._calendar,
                                           background=sel_bg, borderwidth=0, highlightthickness=0)
         canvas.text = canvas.create_text(0, 0, fill=sel_fg, anchor='w')

--- a/ttkwidgets/calendarwidget.py
+++ b/ttkwidgets/calendarwidget.py
@@ -5,7 +5,7 @@ Source: http://svn.python.org/projects/sandbox/trunk/ttk-gsoc/samples/ttkcalenda
 """
 import tkinter as tk
 from tkinter import ttk
-from tkinter import font
+from tkinter import font as tkfont
 import calendar
 
 
@@ -119,14 +119,14 @@ class Calendar(ttk.Frame):
         self._calendar.tag_configure('header', background='grey90')
         self._calendar.insert('', 'end', values=cols, tag='header')
         # adjust its columns width
-        font = font.Font()
+        font = tkfont.Font()
         maxwidth = max(font.measure(col) for col in cols)
         for col in cols:
             self._calendar.column(col, width=maxwidth, minwidth=maxwidth,
                                   anchor='e')
 
     def __setup_selection(self, sel_bg, sel_fg):
-        self._font = font.Font()
+        self._font = tkfont.Font()
         self._canvas = canvas = tk.Canvas(self._calendar,
                                           background=sel_bg, borderwidth=0, highlightthickness=0)
         canvas.text = canvas.create_text(0, 0, fill=sel_fg, anchor='w')

--- a/ttkwidgets/checkboxtreeview.py
+++ b/ttkwidgets/checkboxtreeview.py
@@ -7,10 +7,7 @@ Source: This repository
 Treeview with checkboxes at each item and a noticeable disabled style
 """
 
-try:
-    import ttk
-except ImportError:
-    from tkinter import ttk
+from tkinter import ttk
 
 import os
 from PIL import Image, ImageTk

--- a/ttkwidgets/color/functions.py
+++ b/ttkwidgets/color/functions.py
@@ -28,12 +28,8 @@ Functions and constants
 """
 
 
-try:
-    import tkinter as tk
-    from tkinter import ttk
-except ImportError:
-    import Tkinter as tk
-    import ttk
+import tkinter as tk
+from tkinter import ttk
 from PIL import Image, ImageDraw, ImageTk
 from math import atan2, sqrt, pi
 import colorsys

--- a/ttkwidgets/debugwindow.py
+++ b/ttkwidgets/debugwindow.py
@@ -3,14 +3,9 @@ Author: RedFantom
 License: GNU GPLv3
 Source: This repository
 """
-try:
-    import Tkinter as tk
-    import ttk
-    import tkFileDialog as fd
-except ImportError:
-    import tkinter as tk
-    from tkinter import ttk
-    import tkinter.filedialog as fd
+import tkinter as tk
+from tkinter import ttk
+from tkinter import filedialog as fd
 import sys
 from ttkwidgets import AutoHideScrollbar
 

--- a/ttkwidgets/font/chooser.py
+++ b/ttkwidgets/font/chooser.py
@@ -4,14 +4,9 @@ License: GNU GPLv3
 Source: This repository
 """
 # Based on an idea by Nelson Brochado (https://www.github.com/nbro/tkinter-kit)
-try:
-    import Tkinter as tk
-    import ttk
-    import tkFont as font
-except ImportError:
-    import tkinter as tk
-    from tkinter import ttk
-    from tkinter import font
+import tkinter as tk
+from tkinter import ttk
+from tkinter import font
 from .familylistbox import FontFamilyListbox
 from .sizedropdown import FontSizeDropdown
 from .propertiesframe import FontPropertiesFrame

--- a/ttkwidgets/font/chooser.py
+++ b/ttkwidgets/font/chooser.py
@@ -6,7 +6,7 @@ Source: This repository
 # Based on an idea by Nelson Brochado (https://www.github.com/nbro/tkinter-kit)
 import tkinter as tk
 from tkinter import ttk
-from tkinter import font
+from tkinter import font as tkfont
 from .familylistbox import FontFamilyListbox
 from .sizedropdown import FontSizeDropdown
 from .propertiesframe import FontPropertiesFrame
@@ -129,11 +129,11 @@ class FontChooser(tk.Toplevel):
             return None, None
         else:
             font_tuple = self.__generate_font_tuple()
-            font_obj = font.Font(family=self._family, size=self._size,
-                                 weight=font.BOLD if self._bold else font.NORMAL,
-                                 slant=font.ITALIC if self._italic else font.ROMAN,
-                                 underline=1 if self._underline else 0,
-                                 overstrike=1 if self._overstrike else 0)
+            font_obj = tkfont.Font(family=self._family, size=self._size,
+                                   weight=tkfont.BOLD if self._bold else tkfont.NORMAL,
+                                   slant=tkfont.ITALIC if self._italic else tkfont.ROMAN,
+                                   underline=1 if self._underline else 0,
+                                   overstrike=1 if self._overstrike else 0)
             return font_tuple, font_obj
 
     def _close(self):

--- a/ttkwidgets/font/familydropdown.py
+++ b/ttkwidgets/font/familydropdown.py
@@ -5,7 +5,6 @@ Source: This repository
 """
 # Based on an idea by Nelson Brochado (https://www.github.com/nbro/tkinter-kit)
 import tkinter as tk
-from tkinter import ttk
 from tkinter import font
 from ttkwidgets.autocomplete import AutocompleteCombobox
 

--- a/ttkwidgets/font/familydropdown.py
+++ b/ttkwidgets/font/familydropdown.py
@@ -4,14 +4,9 @@ License: GNU GPLv3
 Source: This repository
 """
 # Based on an idea by Nelson Brochado (https://www.github.com/nbro/tkinter-kit)
-try:
-    import Tkinter as tk
-    import ttk
-    import tkFont as font
-except ImportError:
-    import tkinter as tk
-    from tkinter import ttk
-    from tkinter import font
+import tkinter as tk
+from tkinter import ttk
+from tkinter import font
 from ttkwidgets.autocomplete import AutocompleteCombobox
 
 

--- a/ttkwidgets/font/familylistbox.py
+++ b/ttkwidgets/font/familylistbox.py
@@ -4,14 +4,9 @@ License: GNU GPLv3
 Source: This repository
 """
 # Based on an idea by Nelson Brochado (https://www.github.com/nbro/tkinter-kit)
-try:
-    import Tkinter as tk
-    import ttk
-    import tkFont as font
-except ImportError:
-    import tkinter as tk
-    from tkinter import ttk
-    from tkinter import font
+import tkinter as tk
+from tkinter import ttk
+from tkinter import font
 from ttkwidgets import ScrolledListbox
 
 

--- a/ttkwidgets/font/familylistbox.py
+++ b/ttkwidgets/font/familylistbox.py
@@ -5,7 +5,6 @@ Source: This repository
 """
 # Based on an idea by Nelson Brochado (https://www.github.com/nbro/tkinter-kit)
 import tkinter as tk
-from tkinter import ttk
 from tkinter import font
 from ttkwidgets import ScrolledListbox
 

--- a/ttkwidgets/font/propertiesframe.py
+++ b/ttkwidgets/font/propertiesframe.py
@@ -4,14 +4,9 @@ License: GNU GPLv3
 Source: This repository
 """
 # Based on an idea by Nelson Brochado (https://www.github.com/nbro/tkinter-kit)
-try:
-    import Tkinter as tk
-    import ttk
-    import tkFont as font
-except ImportError:
-    import tkinter as tk
-    from tkinter import ttk
-    from tkinter import font
+import tkinter as tk
+from tkinter import ttk
+from tkinter import font
 
 
 class FontPropertiesFrame(ttk.Frame):

--- a/ttkwidgets/font/propertiesframe.py
+++ b/ttkwidgets/font/propertiesframe.py
@@ -6,7 +6,6 @@ Source: This repository
 # Based on an idea by Nelson Brochado (https://www.github.com/nbro/tkinter-kit)
 import tkinter as tk
 from tkinter import ttk
-from tkinter import font
 
 
 class FontPropertiesFrame(ttk.Frame):

--- a/ttkwidgets/font/selectframe.py
+++ b/ttkwidgets/font/selectframe.py
@@ -4,14 +4,9 @@ License: GNU GPLv3
 Source: This repository
 """
 # Based on an idea by Nelson Brochado (https://www.github.com/nbro/tkinter-kit)
-try:
-    import Tkinter as tk
-    import ttk
-    import tkFont as font
-except ImportError:
-    import tkinter as tk
-    from tkinter import ttk
-    from tkinter import font
+import tkinter as tk
+from tkinter import ttk
+from tkinter import font
 from .familydropdown import FontFamilyDropdown
 from .propertiesframe import FontPropertiesFrame
 from .sizedropdown import FontSizeDropdown

--- a/ttkwidgets/font/selectframe.py
+++ b/ttkwidgets/font/selectframe.py
@@ -4,7 +4,6 @@ License: GNU GPLv3
 Source: This repository
 """
 # Based on an idea by Nelson Brochado (https://www.github.com/nbro/tkinter-kit)
-import tkinter as tk
 from tkinter import ttk
 from tkinter import font
 from .familydropdown import FontFamilyDropdown

--- a/ttkwidgets/font/sizedropdown.py
+++ b/ttkwidgets/font/sizedropdown.py
@@ -4,14 +4,9 @@ License: GNU GPLv3
 Source: This repository
 """
 # Based on an idea by Nelson Brochado (https://www.github.com/nbro/tkinter-kit)
-try:
-    import Tkinter as tk
-    import ttk
-    import tkFont as font
-except ImportError:
-    import tkinter as tk
-    from tkinter import ttk
-    from tkinter import font
+import tkinter as tk
+from tkinter import ttk
+from tkinter import font
 from ttkwidgets.autocomplete import AutocompleteCombobox
 
 

--- a/ttkwidgets/font/sizedropdown.py
+++ b/ttkwidgets/font/sizedropdown.py
@@ -4,9 +4,6 @@ License: GNU GPLv3
 Source: This repository
 """
 # Based on an idea by Nelson Brochado (https://www.github.com/nbro/tkinter-kit)
-import tkinter as tk
-from tkinter import ttk
-from tkinter import font
 from ttkwidgets.autocomplete import AutocompleteCombobox
 
 

--- a/ttkwidgets/frames/balloon.py
+++ b/ttkwidgets/frames/balloon.py
@@ -3,12 +3,8 @@ Author: RedFantom
 License: GNU GPLv3
 Source: This repository
 """
-try:
-    import Tkinter as tk
-    import ttk
-except ImportError:
-    import tkinter.ttk as ttk
-    import tkinter as tk
+import tkinter as tk
+from tkinter import ttk
 from PIL import Image, ImageTk
 import os
 from ttkwidgets.utilities import get_assets_directory

--- a/ttkwidgets/frames/scrolledframe.py
+++ b/ttkwidgets/frames/scrolledframe.py
@@ -6,12 +6,8 @@ Source: This repository
 # The following sites were used for reference in the creation of this file:
 # http://code.activestate.com/recipes/578894-mousewheel-binding-to-scrolling-area-tkinter-multi/
 # http://tkinter.unpythonic.net/wiki/VerticalScrolledFrame
-try:
-    import Tkinter as tk
-    import ttk
-except ImportError:
-    import tkinter as tk
-    from tkinter import ttk
+import tkinter as tk
+from tkinter import ttk
 from ttkwidgets import AutoHideScrollbar
 
 

--- a/ttkwidgets/frames/toggledframe.py
+++ b/ttkwidgets/frames/toggledframe.py
@@ -3,12 +3,8 @@ Author: RedFantom
 License: GNU GPLv3
 Source: This repository
 """
-try:
-    import Tkinter as tk
-    import ttk
-except ImportError:
-    import tkinter as tk
-    from tkinter import ttk
+import tkinter as tk
+from tkinter import ttk
 import os
 from PIL import Image, ImageTk
 from ttkwidgets.utilities import get_assets_directory

--- a/ttkwidgets/itemscanvas.py
+++ b/ttkwidgets/itemscanvas.py
@@ -3,12 +3,8 @@ Author: RedFantom
 License: GNU GPLv3
 Source: This repository
 """
-try:
-    import Tkinter as tk
-    import ttk
-except ImportError:
-    import tkinter as tk
-    from tkinter import ttk
+import tkinter as tk
+from tkinter import ttk
 import os
 from PIL import Image, ImageTk
 

--- a/ttkwidgets/linklabel.py
+++ b/ttkwidgets/linklabel.py
@@ -4,12 +4,8 @@ License: GNU GPLv3
 Source: This repository
 """
 # Based on an idea by Nelson Brochado (https://www.github.com/nbrol/tkinter-kit)
-try:
-    import Tkinter as tk
-    import ttk
-except ImportError:
-    import tkinter as tk
-    from tkinter import ttk
+import tkinter as tk
+from tkinter import ttk
 import webbrowser
 
 

--- a/ttkwidgets/scaleentry.py
+++ b/ttkwidgets/scaleentry.py
@@ -3,12 +3,8 @@ Author: RedFantom and Juliette Monsel
 License: GNU GPLv3
 Source: This repository
 """
-try:
-    import Tkinter as tk
-    import ttk
-except ImportError:
-    import tkinter as tk
-    from tkinter import ttk
+import tkinter as tk
+from tkinter import ttk
 
 
 class ScaleEntry(ttk.Frame):

--- a/ttkwidgets/scrolledlistbox.py
+++ b/ttkwidgets/scrolledlistbox.py
@@ -3,12 +3,8 @@ Author: RedFantom
 License: GNU GPLv3
 Source: This repository
 """
-try:
-    import Tkinter as tk
-    import ttk
-except ImportError:
-    import tkinter as tk
-    from tkinter import ttk
+import tkinter as tk
+from tkinter import ttk
 from ttkwidgets import AutoHideScrollbar
 
 

--- a/ttkwidgets/table.py
+++ b/ttkwidgets/table.py
@@ -6,12 +6,8 @@ Source: This repository
 
 Table made out of a Treeview with possibility to drag rows and columns and to sort columns.
 """
-try:
-    import tkinter as tk
-    from tkinter import ttk
-except ImportError:
-    import Tkinter as tk
-    import ttk
+import tkinter as tk
+from tkinter import ttk
 from PIL import ImageTk, Image
 from ttkwidgets.utilities import get_assets_directory, os
 

--- a/ttkwidgets/tickscale.py
+++ b/ttkwidgets/tickscale.py
@@ -3,12 +3,8 @@ Author: Juliette Monsel
 License: GNU GPLv3
 Source: This repository
 """
-try:
-    import Tkinter as tk
-    import ttk
-except ImportError:
-    from tkinter import ttk
-    import tkinter as tk
+import tkinter as tk
+from tkinter import ttk
 
 
 class TickScale(ttk.Frame):

--- a/ttkwidgets/timeline.py
+++ b/ttkwidgets/timeline.py
@@ -3,12 +3,8 @@ Author: RedFantom
 License: GNU GPLv3
 Source: This repository
 """
-try:
-    import Tkinter as tk
-    import ttk
-except ImportError:
-    import tkinter as tk
-    from tkinter import ttk
+import tkinter as tk
+from tkinter import ttk
 from ttkwidgets.utilities import open_icon
 from collections import OrderedDict
 from ttkwidgets import AutoHideScrollbar


### PR DESCRIPTION
These commits remove the support for Python 2 by removing the `try`-`except ImportError` clauses when import `Tkinter`, `tkinter` or any of its components. Unused imports of any of these components are also removed from files where they are not needed and tests for Python 3.7 and 3.8 are enabled on both CI platforms.

There is one point of discussion though: should support for Python 3.4 be kept? Python 3.4 is already EOL, unlike Python 2.7, which is going to be EOL very soon. Python 3.4 still is the only distribution available on some embedded platforms (like the BeagleBone Black, AFAIK), but these are not the target platforms for this library. The library may still be used on those platforms by compiling Python 3.5 or higher for them instead. Dropping Python 3.4 support means support for type hinting within the library, which would be a great advantage over the typing strings that would otherwise have to be used.

In my experience, using type hinting, especially in libraries, is extremely beneficial because modern IDEs like PyCharm include support for type hint checking while coding, so when functions are called or arguments passed, mistakes may be quickly spotted rather than during runtime.