### PR TITLE
Merge formateli:run_example_script into master to add example runner

### DIFF
--- a/docs/source/generate_examples.py
+++ b/docs/source/generate_examples.py
@@ -18,6 +18,11 @@ EXAMPLES_FILE = \
     "Examples\n" \
     "========\n" \
     "\n" \
+    "Examples can be run in one of two ways:\n" \
+    "    - Run each example file as a stand alone script.\n" \
+    "    - Run the *run.py* script, which open a window\n" \
+    "      with all reports at once represented each one by a button.\n" \
+    "\n" \
     "{}"
 
 TOCTREE_TEMPLATE = \
@@ -36,6 +41,8 @@ example_files = list()
 pkgs = {}
 
 for example in EXAMPLES:
+    if example == 'run.py':
+        continue
     path = os.path.join(FOLDER, example)
     with open(path) as fi:
         lines = fi.readlines()

--- a/examples/run.py
+++ b/examples/run.py
@@ -28,12 +28,9 @@ class _SampleButton:
         self.btn.grid(row=row, column=col, sticky="nsew") 
 
     def run_example(self, event=None):
-        try:
-            subprocess.run(
-                ['python', 'example_' + self.btn['text'] + '.py'], env=EXAMPLE_ENV
-            )
-        except Exception as e:
-            print(e)
+        subprocess.run(
+            ['python', 'example_' + self.btn['text'] + '.py'], env=EXAMPLE_ENV
+        )
 
 
 def _get_samples():

--- a/examples/run.py
+++ b/examples/run.py
@@ -6,7 +6,6 @@ Show all examples located in this example folder.
 Main window show a button for each example.
 """
 import os
-import os
 import subprocess
 import tkinter as tk
 from tkinter import ttk
@@ -23,14 +22,11 @@ else:
 
 class _SampleButton:
     def __init__(self, root, text, col, row):
-        self.root = root
         self.btn = ttk.Button(root, text=text, command=self.run_example)
         self.btn.grid(row=row, column=col, sticky="nsew") 
 
     def run_example(self, event=None):
-        subprocess.run(
-            ['python', 'example_' + self.btn['text'] + '.py'], env=EXAMPLE_ENV
-        )
+        subprocess.Popen(['python', 'example_' + self.btn['text'] + '.py'], env=EXAMPLE_ENV)
 
 
 def _get_samples():

--- a/examples/run.py
+++ b/examples/run.py
@@ -1,0 +1,90 @@
+# Copyright (c) 2020 Fredy Ramirez <https://formateli.com>
+# For license see LICENSE
+"""
+run.py
+Show all examples located in this example folder.
+Main window show a button for each example.
+"""
+import sys, os
+import subprocess
+import tkinter as tk
+from tkinter import ttk
+
+_DIR = os.path.dirname(os.path.realpath(__file__))
+_DIR = os.path.normpath(os.path.join(_DIR, '..'))
+
+EXAMPLE_ENV = os.environ.copy()
+if not 'PYTHONPATH' in EXAMPLE_ENV:
+    EXAMPLE_ENV["PYTHONPATH"] = _DIR
+else:
+    EXAMPLE_ENV["PYTHONPATH"] = _DIR + os.pathsep + EXAMPLE_ENV["PYTHONPATH"]
+
+
+class _SampleButton:
+    def __init__(self, root, text, col, row):
+        self.root = root
+        self.btn = ttk.Button(root, text=text, command=self.run_example)
+        self.btn.grid(row=row, column=col, sticky="nsew") 
+
+    def run_example(self, event=None):
+        try:
+            subprocess.run(
+                [
+                    'python',
+                    'example_' + self.btn['text'] + '.py'
+                ],
+                env=EXAMPLE_ENV
+            )
+        except Exception as e:
+            print(e)
+
+
+def _get_samples():
+    result = []
+    dir_ = os.path.dirname(os.path.realpath(__file__))
+    files = os.listdir(dir_)
+    for f in files:
+        if f == 'run.py':
+            continue
+        fp = os.path.join(dir_, f)
+        if os.path.isfile(f) and f.endswith('.py'):
+            f = f[8:] # remove example_
+            f = f[0:len(f)-3] # remove .py
+            result.append([f, fp])
+    return result
+
+
+def _add_samples(window):
+    samples = _get_samples()
+    total_samples = len(samples)
+    max_col_count = 5
+    row = -1
+    col = -1
+    row_checked = False
+    for s in samples:
+        if col == -1 or (row + 1) > max_col_count:
+            col += 1
+            window.grid_columnconfigure(col, weight=1)
+
+        if row == -1 or (row + 1) > max_col_count:
+            if (row + 1) > max_col_count:
+                row_checked = True
+            row = 0
+
+        if not row_checked:
+            window.grid_rowconfigure(row, weight=1)
+
+        _SampleButton(window, s[0], col, row)
+        row += 1
+
+
+if __name__ == '__main__':
+    root = tk.Tk()
+    root.title('ttkwidget Examples')
+    root.geometry('800x500')
+    _add_samples(root)
+    root.mainloop()
+    try:
+        root.destroy()
+    except:
+        pass

--- a/examples/run.py
+++ b/examples/run.py
@@ -5,7 +5,8 @@ run.py
 Show all examples located in this example folder.
 Main window show a button for each example.
 """
-import sys, os
+import os
+import os
 import subprocess
 import tkinter as tk
 from tkinter import ttk
@@ -29,11 +30,7 @@ class _SampleButton:
     def run_example(self, event=None):
         try:
             subprocess.run(
-                [
-                    'python',
-                    'example_' + self.btn['text'] + '.py'
-                ],
-                env=EXAMPLE_ENV
+                ['python', 'example_' + self.btn['text'] + '.py'], env=EXAMPLE_ENV
             )
         except Exception as e:
             print(e)
@@ -48,15 +45,14 @@ def _get_samples():
             continue
         fp = os.path.join(dir_, f)
         if os.path.isfile(f) and f.endswith('.py'):
-            f = f[8:] # remove example_
-            f = f[0:len(f)-3] # remove .py
+            f = f[8:]           # remove example_
+            f = f[0:len(f)-3]   # remove .py
             result.append([f, fp])
     return result
 
 
 def _add_samples(window):
     samples = _get_samples()
-    total_samples = len(samples)
     max_col_count = 5
     row = -1
     col = -1
@@ -80,11 +76,7 @@ def _add_samples(window):
 
 if __name__ == '__main__':
     root = tk.Tk()
-    root.title('ttkwidget Examples')
+    root.title('ttkwidgets Examples')
     root.geometry('800x500')
     _add_samples(root)
     root.mainloop()
-    try:
-        root.destroy()
-    except:
-        pass


### PR DESCRIPTION
Show all examples at once running *run.py* script located in examples directory.
- it is not necessary to ttkwidgets to be installed, run.py always include module path.
- All examples can be run as script one by one or can be executed from run.py
- Entries to the sphinx documentation were added.
