### PR TITLE
Merge readme into master for fixes to README.md

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,7 +6,7 @@ environment:
     - PYTHON: "C:\\PYTHON37"
     - PYTHON: "C:\\PYTHON38"
 install:
-  - "%PYTHON%\\python.exe -m pip install codecov coverage nose mock pynput"
+  - "%PYTHON%\\python.exe -m pip install -U codecov coverage nose mock pynput setuptools pip"
 build: off
 test_script:
   - "%PYTHON%\\python.exe -m pip install ."

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ before_install:
   - sleep 3
 install:
   - sudo apt-get install python-tk python3-tk
+  - python -m pip install -U setuptools pip
   - python -m pip install nose coverage codecov mock pynput
 script:
   - python -m pip install .

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ttkwidgets
 [![Build Status](https://travis-ci.org/TkinterEP/ttkwidgets.svg?branch=master)](https://travis-ci.org/TkinterEP/ttkwidgets)
 [![Build status](https://ci.appveyor.com/api/projects/status/eegux50s3kmb5w9g/branch/master?svg=true)](https://ci.appveyor.com/project/RedFantom/ttkwidgets-pq6y3)
-[![codecov](https://codecov.io/gh/RedFantom/ttkwidgets/branch/master/graph/badge.svg)](https://codecov.io/gh/RedFantom/ttkwidgets)
+[![codecov](https://codecov.io/gh/TkinterEP/ttkwidgets/branch/master/graph/badge.svg)](https://codecov.io/gh/TkinterEP/ttkwidgets)
 [![PyPI version](https://badge.fury.io/py/ttkwidgets.svg)](https://badge.fury.io/py/ttkwidgets)
 [![License: GPL v3](https://img.shields.io/badge/License-GPL%20v3-blue.svg)](http://www.gnu.org/licenses/gpl-3.0)
 [![Documentation Status](https://readthedocs.org/projects/ttkwidgets/badge/?version=latest)](https://ttkwidgets.readthedocs.io/en/latest/)

--- a/setup.py
+++ b/setup.py
@@ -1,62 +1,14 @@
-# Copyright (c) RedFantom 2017
-# For license see LICENSE
+"""
+Author: See AUTHORS.md
+License: GNU GPLv3
+Copyright (c) 2018-2020 The ttkwidgets authors
+"""
 from setuptools import setup
 
-long_description = """
-ttkwidgets
-==========
 
-|Travis| |Appveyor| |Codecov| |Pypi| |License|
-
-A collection of widgets for Tkinter's ttk extensions by various authors
-
-
-License
--------
-
-ttkwidgets: A collection of widgets for Tkinter's ttk extensions by various authors 
-Copyright (C) RedFantom 2017
-Copyright (C) The Python Team
-Copyright (C) Mitja Martini 2008
-Copyright (C) Russell Adams 2011
-Copyright (C) Juliette Monsel 2017
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
-
-
-.. |Travis| image:: https://travis-ci.org/RedFantom/ttkwidgets.svg?branch=master
-    :alt: Travis CI Build Status
-    :target: https://travis-ci.org/RedFantom/ttkwidgets
-
-.. |Appveyor| image:: https://ci.appveyor.com/api/projects/status/c6j6td273u3y6rw7/branch/master?svg=true
-    :alt: Appveyor Build Status
-    :target: https://ci.appveyor.com/project/RedFantom/ttkwidgets/branch/master
-
-.. |Codecov| image:: https://codecov.io/gh/RedFantom/ttkwidgets/branch/master/graph/badge.svg
-    :alt: Code Coverage
-    :target: https://codecov.io/gh/RedFantom/ttkwidgets
-    
-.. |Pypi| image:: https://badge.fury.io/py/ttkwidgets.svg
-    :alt: PyPI version
-    :target: https://badge.fury.io/py/ttkwidgets
-    
-.. |License| image:: https://img.shields.io/badge/License-GPL%20v3-blue.svg
-    :alt: License: GPL v3
-    :target: http://www.gnu.org/licenses/gpl-3.0
-    
-"""
+def read(file_name: str):
+    with open(file_name) as fi:
+        return fi.read()
 
 setup(
     name="ttkwidgets",
@@ -65,7 +17,8 @@ setup(
     package_data={"ttkwidgets": ["assets/*"]},
     version="0.11.0",
     description=" A collection of widgets for Tkinter's ttk extensions by various authors ",
-    long_description=long_description,
+    long_description=read("README.md"),
+    long_description_content_type="text/markdown",
     author="The ttkwidgets authors",
     url="https://www.github.com/RedFantom/ttkwidgets",
     download_url="https://www.github.com/RedFantom/ttkwidgets/releases",


### PR DESCRIPTION
- Fix the Codecov badge
- Read the `long_description` in setup from README.md now that MarkDown is supported on PyPI to keep it up-to-date
- Add updating of `pip` and `setuptools` to the Travis-CI and AppVeyor configs to prevent issues with it