### PR TITLE
Fix SyntaxWarnings in newer Python 3 releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
   - sleep 3
 install:
   - sudo apt-get install python-tk python3-tk
-  - python -m pip install -U setuptools pip
+  - python -m pip install -U setuptools pip importlib-metadata
   - python -m pip install nose coverage codecov mock pynput
 script:
   - python -m pip install .

--- a/tests/test_linklabel.py
+++ b/tests/test_linklabel.py
@@ -36,3 +36,12 @@ class TestLinkLabel(BaseWidgetTest):
         self.window.update()
         label["clicked_color"] = "purple"
         self.window.update()
+
+    def test_linklabel_cget(self):
+        label = LinkLabel(self.window, link="www.google.com", text="Visit Google")
+        label.pack()
+        assert label.cget("hover_color") == label._hover_color
+        assert label.cget("link") == label._link
+        assert label.cget("normal_color") == label._normal_color
+        assert label.cget("clicked_color") == label._clicked_color
+        assert label.cget("text") == "Visit Google"

--- a/ttkwidgets/debugwindow.py
+++ b/ttkwidgets/debugwindow.py
@@ -61,7 +61,7 @@ class DebugWindow(tk.Toplevel):
     def save(self):
         """Save widget content."""
         file_name = fd.asksaveasfilename()
-        if file_name is "" or file_name is None:
+        if file_name == "" or file_name is None:
             return
         with open(file_name, "w") as f:
             f.write(self.text.get("1.0", tk.END))

--- a/ttkwidgets/itemscanvas.py
+++ b/ttkwidgets/itemscanvas.py
@@ -104,21 +104,20 @@ class ItemsCanvas(ttk.Frame):
         """
         self.set_current()
         results = self.canvas.find_withtag(tk.CURRENT)
-        if len(results) == 0:
-            return
-        item = results[0]
-        rectangle = self.items[item]
-        self.config(cursor="exchange")
-        self.canvas.itemconfigure(item, fill="blue")
-        xc, yc = self.canvas.canvasx(event.x), self.canvas.canvasy(event.y)
-        dx, dy = xc - self.current_coords[0], yc - self.current_coords[1]
-        self.current_coords = xc, yc
-        self.canvas.move(item, dx, dy)
-        # check whether the new position of the item respects the boundaries
-        x, y = self.canvas.coords(item)
-        x, y = max(min(x, self._max_x), 0), max(min(y, self._max_y), 0)
-        self.canvas.coords(item, x, y)
-        self.canvas.coords(rectangle, self.canvas.bbox(item))
+        if results:
+            item = results[0]
+            rectangle = self.items[item]
+            self.config(cursor="exchange")
+            self.canvas.itemconfigure(item, fill="blue")
+            xc, yc = self.canvas.canvasx(event.x), self.canvas.canvasy(event.y)
+            dx, dy = xc - self.current_coords[0], yc - self.current_coords[1]
+            self.current_coords = xc, yc
+            self.canvas.move(item, dx, dy)
+            # check whether the new position of the item respects the boundaries
+            x, y = self.canvas.coords(item)
+            x, y = max(min(x, self._max_x), 0), max(min(y, self._max_y), 0)
+            self.canvas.coords(item, x, y)
+            self.canvas.coords(rectangle, self.canvas.bbox(item))
 
     def right_press(self, event):
         """

--- a/ttkwidgets/itemscanvas.py
+++ b/ttkwidgets/itemscanvas.py
@@ -81,7 +81,6 @@ class ItemsCanvas(ttk.Frame):
         if self.current:
             self.canvas.itemconfigure(self.current, fill=self.item_colors[self.current][1])
             self.current = None
-            return
 
     def left_release(self, event):
         """

--- a/ttkwidgets/itemscanvas.py
+++ b/ttkwidgets/itemscanvas.py
@@ -103,20 +103,22 @@ class ItemsCanvas(ttk.Frame):
         """
         self.set_current()
         results = self.canvas.find_withtag(tk.CURRENT)
-        if results:
-            item = results[0]
-            rectangle = self.items[item]
-            self.config(cursor="exchange")
-            self.canvas.itemconfigure(item, fill="blue")
-            xc, yc = self.canvas.canvasx(event.x), self.canvas.canvasy(event.y)
-            dx, dy = xc - self.current_coords[0], yc - self.current_coords[1]
-            self.current_coords = xc, yc
-            self.canvas.move(item, dx, dy)
-            # check whether the new position of the item respects the boundaries
-            x, y = self.canvas.coords(item)
-            x, y = max(min(x, self._max_x), 0), max(min(y, self._max_y), 0)
-            self.canvas.coords(item, x, y)
-            self.canvas.coords(rectangle, self.canvas.bbox(item))
+        if not results:
+            return
+
+        item = results[0]
+        rectangle = self.items[item]
+        self.config(cursor="exchange")
+        self.canvas.itemconfigure(item, fill="blue")
+        xc, yc = self.canvas.canvasx(event.x), self.canvas.canvasy(event.y)
+        dx, dy = xc - self.current_coords[0], yc - self.current_coords[1]
+        self.current_coords = xc, yc
+        self.canvas.move(item, dx, dy)
+        # check whether the new position of the item respects the boundaries
+        x, y = self.canvas.coords(item)
+        x, y = max(min(x, self._max_x), 0), max(min(y, self._max_y), 0)
+        self.canvas.coords(item, x, y)
+        self.canvas.coords(rectangle, self.canvas.bbox(item))
 
     def right_press(self, event):
         """

--- a/ttkwidgets/itemscanvas.py
+++ b/ttkwidgets/itemscanvas.py
@@ -82,11 +82,6 @@ class ItemsCanvas(ttk.Frame):
             self.canvas.itemconfigure(self.current, fill=self.item_colors[self.current][1])
             self.current = None
             return
-        results = self.canvas.find_withtag(tk.CURRENT)
-        if len(results) == 0:
-            return
-        self.current = results[0]
-        self.canvas.itemconfigure(self.current, fill=self.item_colors[self.current][2])
 
     def left_release(self, event):
         """

--- a/ttkwidgets/itemscanvas.py
+++ b/ttkwidgets/itemscanvas.py
@@ -83,7 +83,7 @@ class ItemsCanvas(ttk.Frame):
             self.current = None
             return
         results = self.canvas.find_withtag(tk.CURRENT)
-        if len(results) is 0:
+        if len(results) == 0:
             return
         self.current = results[0]
         self.canvas.itemconfigure(self.current, fill=self.item_colors[self.current][2])
@@ -109,7 +109,7 @@ class ItemsCanvas(ttk.Frame):
         """
         self.set_current()
         results = self.canvas.find_withtag(tk.CURRENT)
-        if len(results) is 0:
+        if len(results) == 0:
             return
         item = results[0]
         rectangle = self.items[item]

--- a/ttkwidgets/linklabel.py
+++ b/ttkwidgets/linklabel.py
@@ -81,13 +81,13 @@ class LinkLabel(ttk.Label):
 
         To get the list of options for this widget, call the method :meth:`~LinkLabel.keys`.
         """
-        if key is "link":
+        if key == "link":
             return self._link
-        elif key is "hover_color":
+        elif key == "hover_color":
             return self._hover_color
-        elif key is "normal_color":
+        elif key == "normal_color":
             return self._normal_color
-        elif key is "clicked_color":
+        elif key == "clicked_color":
             return self._clicked_color
         else:
             return ttk.Label.cget(self, key)


### PR DESCRIPTION
Newer Python releases (Python 3.8 in my case) raise `SyntaxWarning`s for comparing with a literal using `is`. This should prevent that.