### PR TITLE
Make FontFamilyDropdown compatible w/ Python 3.13

### DIFF
--- a/ttkwidgets/font/familydropdown.py
+++ b/ttkwidgets/font/familydropdown.py
@@ -3,9 +3,11 @@ Author: RedFantom
 License: GNU GPLv3
 Source: This repository
 """
+
 # Based on an idea by Nelson Brochado (https://www.github.com/nbro/tkinter-kit)
 import tkinter as tk
 from tkinter import font
+
 from ttkwidgets.autocomplete import AutocompleteCombobox
 
 
@@ -28,7 +30,13 @@ class FontFamilyDropdown(AutocompleteCombobox):
         self._fonts = font_families
         self._font = tk.StringVar(master)
         self.__callback = callback
-        AutocompleteCombobox.__init__(self, master, textvariable=self._font, completevalues=font_families, **kwargs)
+        AutocompleteCombobox.__init__(
+            self,
+            master,
+            textvariable=self._font,
+            completevalues=font_families,
+            **kwargs,
+        )
         self.bind("<<ComboboxSelected>>", self._on_select)
         self.bind("<Return>", self._on_select)
 
@@ -49,7 +57,7 @@ class FontFamilyDropdown(AutocompleteCombobox):
         :return: None if no font is selected and font family name if one is selected.
         :rtype: None or str
         """
-        if self._font.get() is "" or self._font.get() not in self._fonts:
+        if self._font.get() == "" or self._font.get() not in self._fonts:
             return None
         else:
             return self._font.get()

--- a/ttkwidgets/font/familylistbox.py
+++ b/ttkwidgets/font/familylistbox.py
@@ -3,9 +3,11 @@ Author: RedFantom
 License: GNU GPLv3
 Source: This repository
 """
+
 # Based on an idea by Nelson Brochado (https://www.github.com/nbro/tkinter-kit)
 import tkinter as tk
 from tkinter import font
+
 from ttkwidgets import ScrolledListbox
 
 
@@ -54,6 +56,6 @@ class FontFamilyListbox(ScrolledListbox):
         :rtype: None or str
         """
         selection = self.listbox.curselection()
-        if len(selection) is 0:
+        if not len(selection):
             return None
         return self.font_indexes[self.listbox.curselection()[0]]

--- a/ttkwidgets/font/sizedropdown.py
+++ b/ttkwidgets/font/sizedropdown.py
@@ -3,6 +3,7 @@ Author: RedFantom
 License: GNU GPLv3
 Source: This repository
 """
+
 # Based on an idea by Nelson Brochado (https://www.github.com/nbro/tkinter-kit)
 from ttkwidgets.autocomplete import AutocompleteCombobox
 
@@ -45,7 +46,7 @@ class FontSizeDropdown(AutocompleteCombobox):
         :return: None if no value is selected and size if selected.
         :rtype: None or int
         """
-        if self.get() is "":
+        if self.get() == "":
             return None
         else:
             return int(self.get())


### PR DESCRIPTION
Several of the widgets are incompatible w/ Python 3.13 due to the use of `is` instead of `==`. This PR fixes those instances that interfere with the usage of the `FontFamilyDropdown` widget.