### PR TITLE
AutocompleteCombobox: Optional sorting

### DIFF
--- a/tests/test_autocompletewidgets.py
+++ b/tests/test_autocompletewidgets.py
@@ -29,6 +29,14 @@ class TestAutocompleteWidgets(BaseWidgetTest):
         box['completevalues'] = ["Test"]
         self.assertEqual(box['completevalues'], ["Test"])
 
+    def test_autocompletecombobox_unsorted(self):
+        box = AutocompleteCombobox(self.window, completevalues=["Apple", "Pear", "Banana"], sort=False)
+        box.pack()
+        self.window.update()
+
+        self.assertIn('completevalues', box.keys())
+        self.assertEqual(box['completevalues'], ["Apple", "Pear", "Banana"])
+
     def test_autocompleteentry(self):
         entry = AutocompleteEntry(self.window, completevalues=["Apple", "Pear", "Banana"])
         entry.pack()

--- a/ttkwidgets/autocomplete/autocompletecombobox.py
+++ b/ttkwidgets/autocomplete/autocompletecombobox.py
@@ -15,7 +15,7 @@ tk_umlauts = ['odiaeresis', 'adiaeresis', 'udiaeresis', 'Odiaeresis', 'Adiaeresi
 
 class AutocompleteCombobox(ttk.Combobox):
     """:class:`ttk.Combobox` widget that features autocompletion."""
-    def __init__(self, master=None, completevalues=None, **kwargs):
+    def __init__(self, master=None, completevalues=None, sort=True, **kwargs):
         """
         Create an AutocompleteCombobox.
 
@@ -23,9 +23,11 @@ class AutocompleteCombobox(ttk.Combobox):
         :type master: widget
         :param completevalues: autocompletion values
         :type completevalues: list
+        :type sort: boolean (default: True)
         :param kwargs: keyword arguments passed to the :class:`ttk.Combobox` initializer
         """
         ttk.Combobox.__init__(self, master, values=completevalues, **kwargs)
+        self._sort = sort
         self._completion_list = completevalues
         if isinstance(completevalues, list):
             self.set_completion_list(completevalues)
@@ -74,7 +76,12 @@ bind $popdown.f.l <KeyPress> [list ComboListKeyPressed %%W %%K]
         :param completion_list: completion values
         :type completion_list: list
         """
-        self._completion_list = sorted(completion_list, key=str.lower)  # Work with a sorted list
+        
+        if self._sort:
+            # Work with a sorted list if sorting is enabled
+            self._completion_list = sorted(completion_list, key=str.lower)
+        else:
+            self._completion_list = completion_list
         self.configure(values=completion_list)
         self._hits = []
         self._hit_index = 0

--- a/ttkwidgets/autocomplete/autocompletecombobox.py
+++ b/ttkwidgets/autocomplete/autocompletecombobox.py
@@ -78,11 +78,11 @@ bind $popdown.f.l <KeyPress> [list ComboListKeyPressed %%W %%K]
         :type completion_list: list
         """
         
+        # Clone the list to avoid unintentional modifications to the input list
+        self._completion_list = completion_list[:]
         if self._sort:
             # Work with a sorted list if sorting is enabled
-            self._completion_list = sorted(completion_list, key=str.lower)
-        else:
-            self._completion_list = completion_list
+            self._completion_list.sort(key=str.lower)
         self.configure(values=completion_list)
         self._hits = []
         self._hit_index = 0

--- a/ttkwidgets/autocomplete/autocompletecombobox.py
+++ b/ttkwidgets/autocomplete/autocompletecombobox.py
@@ -23,6 +23,7 @@ class AutocompleteCombobox(ttk.Combobox):
         :type master: widget
         :param completevalues: autocompletion values
         :type completevalues: list
+        :param sort: sort autocompletion values, default is True for backwards compatibility with older versions
         :type sort: boolean (default: True)
         :param kwargs: keyword arguments passed to the :class:`ttk.Combobox` initializer
         """


### PR DESCRIPTION
A small patch for the `ttkwidgets.autocomplete.AutocompleteCombobox` that adds an argument to the initializer method that allows the user to decide if they want their list to be sorted automatically or not.

The option to sort automatically is set to True by default to maintain backwards compatibility with older versions of ttkwidgets.

The patch is made for the reason that sometimes you probably don't want your list to be sorted (like for example in my case, a list of months).